### PR TITLE
fix leumi card amount parsing

### DIFF
--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -88,7 +88,7 @@ async function fetchTransactionsByType(page, accountIndex, transactionsType, sta
     return {
       date: moment(txn.dateStr, DATE_FORMAT).toDate(),
       processedDate: moment(txn.processedDateStr, DATE_FORMAT).toDate(),
-      amount: parseFloat(txn.amountStr),
+      amount: parseFloat(txn.amountStr.replace(',', '')),
       description: txn.description.trim(),
     };
   });


### PR DESCRIPTION
Fix a problem where when the amount of a leumi card transaction includes a comma, it is still parsed correctly.