### PR TITLE
change transaction amount to original and charged

### DIFF
--- a/src/scrapers/discount.js
+++ b/src/scrapers/discount.js
@@ -13,7 +13,8 @@ function convertTransactions(txns) {
       identifier: txn.OperationNumber,
       date: moment(txn.OperationDate, DATE_FORMAT).toDate(),
       processedDate: moment(txn.ValueDate, DATE_FORMAT).toDate(),
-      amount: txn.OperationAmount,
+      originalAmount: txn.OperationAmount,
+      chargedAmount: txn.OperationAmount,
       description: txn.OperationDescriptionToDisplay,
     };
   });

--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -62,7 +62,8 @@ function convertTransactions(txns, processedDate) {
       identifier: txn.voucherNumberRatz,
       date: moment(txn.fullPurchaseDate, DATE_FORMAT).toDate(),
       processedDate,
-      amount: -txn.dealSum,
+      originalAmount: -txn.dealSum,
+      chargedAmount: -txn.paymentSum,
       description: txn.fullSupplierNameHeb,
     };
   });

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -62,13 +62,15 @@ function getLoadedRawTransactions(page) {
 
         const dateStr = cells[1].textContent.trim();
         const processedDateStr = cells[2].textContent.trim();
-        const amountStr = cells[6].textContent;
+        const originalAmountStr = cells[6].textContent;
+        const chargedAmountStr = cells[6].textContent;
         const description = cells[3].textContent;
 
         const txn = {
           dateStr,
           processedDateStr,
-          amountStr,
+          originalAmountStr,
+          chargedAmountStr,
           description,
         };
         txns.push(txn);
@@ -92,7 +94,8 @@ async function fetchTransactionsByType(page, accountIndex, transactionsType, sta
     return {
       date: moment(txn.dateStr, DATE_FORMAT).toDate(),
       processedDate: moment(txn.processedDateStr, DATE_FORMAT).toDate(),
-      amount: -parseFloat(txn.amountStr.replace(',', '')),
+      originalAmount: -parseFloat(txn.originalAmountStr.replace(',', '')),
+      chargedAmount: -parseFloat(txn.chargedAmountStr.replace(',', '')),
       description: txn.description.trim(),
     };
   });


### PR DESCRIPTION
Credit cards may have a different value for the original amount and the actual charged amount, so we need to return both.