### PR TITLE
Change the way Leumi Card scraper works

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "rules": {
     "arrow-body-style": 0,
-    "no-shadow": 0
+    "no-shadow": 0,
+    "no-await-in-loop": 0
   },
   "globals": {
     "document": true,

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,0 +1,14 @@
+import moment from 'moment';
+
+export default function getAllMonthMoments(startMoment) {
+  let monthMoment = moment(startMoment).startOf('month');
+
+  const allMonths = [];
+  const startOfNextMonth = moment().startOf('month').add(1, 'month');
+  while (monthMoment.isSameOrBefore(startOfNextMonth)) {
+    allMonths.push(monthMoment);
+    monthMoment = moment(monthMoment).add(1, 'month');
+  }
+
+  return allMonths;
+}

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,11 +1,14 @@
 import moment from 'moment';
 
-export default function getAllMonthMoments(startMoment) {
+export default function getAllMonthMoments(startMoment, includeNext) {
   let monthMoment = moment(startMoment).startOf('month');
 
   const allMonths = [];
-  const startOfNextMonth = moment().startOf('month').add(1, 'month');
-  while (monthMoment.isSameOrBefore(startOfNextMonth)) {
+  let lastMonth = moment().startOf('month');
+  if (includeNext) {
+    lastMonth = lastMonth.add(1, 'month');
+  }
+  while (monthMoment.isSameOrBefore(lastMonth)) {
     allMonths.push(monthMoment);
     monthMoment = moment(monthMoment).add(1, 'month');
   }

--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -128,7 +128,7 @@ async function fetchTransactions(page, startMoment, monthMoment) {
 }
 
 async function fetchAllTransactions(page, startMoment) {
-  const allMonths = getAllMonthMoments(startMoment);
+  const allMonths = getAllMonthMoments(startMoment, true);
   const results = await Promise.all(allMonths.map(async (monthMoment) => {
     return fetchTransactions(page, startMoment, monthMoment);
   }));

--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import { BaseScraper, LOGIN_RESULT } from './base-scraper';
 import { fetchGet, fetchPost } from '../helpers/fetch';
 import { SCRAPE_PROGRESS_TYPES, NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE } from '../constants';
+import getAllMonthMoments from '../helpers/dates';
 
 const BASE_URL = 'https://digital.isracard.co.il';
 const SERVICES_URL = `${BASE_URL}/services/ProxyRequestHandler.ashx`;
@@ -127,15 +128,7 @@ async function fetchTransactions(page, startMoment, monthMoment) {
 }
 
 async function fetchAllTransactions(page, startMoment) {
-  let monthMoment = moment(startMoment).startOf('month');
-
-  const allMonths = [];
-  const startOfNextMonth = moment().startOf('month').add(1, 'month');
-  while (monthMoment.isSameOrBefore(startOfNextMonth)) {
-    allMonths.push(monthMoment);
-    monthMoment = moment(monthMoment).add(1, 'month');
-  }
-
+  const allMonths = getAllMonthMoments(startMoment);
   const results = await Promise.all(allMonths.map(async (monthMoment) => {
     return fetchTransactions(page, startMoment, monthMoment);
   }));


### PR DESCRIPTION
Leumi Card scraper used to work with calling the print function on the statement webpage, but this behavior is prone to some bugs on the Leumi Card website, plus it makes supporting multiple cards per account difficult.
This PR parses the regular statement webpage, rather than the printed webpage.