### PR TITLE
add option to combine installments

### DIFF
--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -1,0 +1,37 @@
+import moment from 'moment';
+import { INSTALLMENTS_TXN_TYPE } from '../constants';
+
+function isNonInitialInstallmentTransaction(txn) {
+  return txn.type === INSTALLMENTS_TXN_TYPE && txn.installments && txn.installments.number > 1;
+}
+
+export function fixInstallments(txns) {
+  return txns.map((txn) => {
+    const clonedTxn = Object.assign({}, txn);
+    if (isNonInitialInstallmentTransaction(clonedTxn)) {
+      const dateMoment = moment(clonedTxn.date);
+      const actualDateMoment = dateMoment.add(clonedTxn.installments.number - 1, 'month');
+      clonedTxn.date = actualDateMoment.toDate();
+    }
+    return clonedTxn;
+  });
+}
+
+export function sortTransactionsByDate(txns) {
+  const cloned = Array.from(txns);
+  cloned.sort((txn1, txn2) => {
+    if (txn1.date.getTime() === txn2.date.getTime()) {
+      return 0;
+    }
+    return txn1.date < txn2.date ? -1 : 1;
+  });
+
+  return cloned;
+}
+
+export function filterOldTransactions(txns, startMoment, combineInstallments) {
+  return txns.filter((txn) => {
+    return startMoment.isSameOrBefore(txn.date) &&
+      (!combineInstallments || !isNonInitialInstallmentTransaction(txn));
+  });
+}

--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -70,8 +70,8 @@ function getInstallmentsInfo(txn) {
   }
 
   return {
-    number: matches[0],
-    total: matches[1],
+    number: parseInt(matches[0], 10),
+    total: parseInt(matches[1], 10),
   };
 }
 

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -78,8 +78,8 @@ function getInstallmentsInfo(comments) {
   }
 
   return {
-    number: matches[0],
-    total: matches[1],
+    number: parseInt(matches[0], 10),
+    total: parseInt(matches[1], 10),
   };
 }
 

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -6,6 +6,7 @@ import { waitForRedirect } from '../helpers/navigation';
 import { waitUntilElementFound } from '../helpers/elements-interactions';
 import { NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE, SHEKEL_CURRENCY } from '../constants';
 import getAllMonthMoments from '../helpers/dates';
+import { fixInstallments, sortTransactionsByDate, filterOldTransactions } from '../helpers/transactions';
 
 const BASE_URL = 'https://online.leumi-card.co.il';
 const DATE_FORMAT = 'DD/MM/YYYY';
@@ -190,15 +191,13 @@ async function fetchTransactions(page, options, accountNumber) {
   const result = await fetchTransactionsForMonth(page);
   allResults = addResult(allResults, result);
 
-  const allTxns = allResults[accountNumber];
-  allTxns.sort((txn1, txn2) => {
-    if (txn1.date.getTime() === txn2.date.getTime()) {
-      return 0;
-    }
-    return txn1.date < txn2.date ? -1 : 1;
-  });
-
-  return allTxns.filter(txn => startMoment.isSameOrBefore(txn.date));
+  let allTxns = allResults[accountNumber];
+  if (!options.combineInstallments) {
+    allTxns = fixInstallments(allTxns);
+  }
+  allTxns = sortTransactionsByDate(allTxns);
+  allTxns = filterOldTransactions(allTxns, startMoment, options.combineInstallments);
+  return allTxns;
 }
 
 async function getAccountData(page, options) {


### PR DESCRIPTION
User can specify `combineInstallments` in options to make all installments transactions merge into one

implements #36 