### PR TITLE
ignore total line in isracard

### DIFF
--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -79,7 +79,7 @@ function getTransactionType(txn) {
 }
 
 function convertTransactions(txns, processedDate) {
-  return txns.map((txn) => {
+  return txns.filter(txn => txn.dealSumType !== '1').map((txn) => {
     return {
       type: getTransactionType(txn),
       identifier: txn.voucherNumberRatz,


### PR DESCRIPTION
for some reason isracard returns a transaction which represents the total amount, so we need to filter it out