### PR TITLE
Support multiple accounts

### DIFF
--- a/src/scrapers/discount.js
+++ b/src/scrapers/discount.js
@@ -47,8 +47,10 @@ async function fetchAccountData(page, options) {
 
   const accountData = {
     success: true,
-    accountNumber,
-    txns,
+    accounts: [{
+      accountNumber,
+      txns,
+    }],
   };
 
   return accountData;

--- a/src/scrapers/isracard.js
+++ b/src/scrapers/isracard.js
@@ -152,18 +152,16 @@ async function fetchAllTransactions(page, options, startMoment) {
     });
   });
 
-  const lastResult = results[results.length - 1];
-  const firstAccountNumberOfLastMonth = Object.keys(lastResult).filter((accountNumber) => {
-    return lastResult[accountNumber].index === 0;
-  })[0];
-
-  let firstAccountNumberOfLastMonthTxns = combinedTxns[firstAccountNumberOfLastMonth];
-  firstAccountNumberOfLastMonthTxns = firstAccountNumberOfLastMonthTxns.sort((a, b) => {
-    return a.date - b.date;
+  const accounts = Object.keys(combinedTxns).map((accountNumber) => {
+    return {
+      accountNumber,
+      txns: combinedTxns[accountNumber],
+    };
   });
+
   return {
-    accountNumber: firstAccountNumberOfLastMonth,
-    txns: firstAccountNumberOfLastMonthTxns,
+    success: true,
+    accounts,
   };
 }
 
@@ -241,16 +239,7 @@ class IsracardScraper extends BaseScraper {
     const startDate = this.options.startDate || defaultStartMoment.toDate();
     const startMoment = moment.max(defaultStartMoment, moment(startDate));
 
-    const txnsResult = await fetchAllTransactions(this.page, this.options, startMoment);
-    if (!txnsResult) {
-      throw new Error('unknown error while fetching data');
-    }
-
-    return {
-      success: true,
-      accountNumber: txnsResult.accountNumber,
-      txns: txnsResult.txns,
-    };
+    return fetchAllTransactions(this.page, this.options, startMoment);
   }
 }
 


### PR DESCRIPTION
if the bank has data for more than one account, all of them will be returned.
the only exception is discount scraper, which supports the new signature, but only returns one bank account.

resolves #15 