### PR TITLE
A tiny improvement in NPM scripts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src",
-    "prepublishOnly": "node_modules/babel-cli/bin/babel.js src --out-dir lib"
+    "prepublishOnly": "babel src --out-dir lib"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Did you know the inside NPM scripts you can access your dependencies executables as if the where globals?

That means that:
```
"prepublishOnly": "node_modules/babel-cli/bin/babel.js src --out-dir lib"
```

Is the same as:
```
"prepublishOnly": "babel src --out-dir lib"
```

Nice, isn't it? 😊
