### PR TITLE
Fix LeumiCard scraper

### DIFF
--- a/src/helpers/navigation.js
+++ b/src/helpers/navigation.js
@@ -9,20 +9,24 @@ async function waitForNavigation(page) {
   await page.waitForNavigation();
 }
 
-async function getCurrentUrl(page) {
-  return page.evaluate(() => window.location.href);
+async function getCurrentUrl(page, clientSide = false) {
+  if (clientSide) {
+    return page.evaluate(() => window.location.href);
+  }
+
+  return page.url();
 }
 
-async function waitForRedirect(page, timeout = 20000) {
-  const initial = await getCurrentUrl(page);
+async function waitForRedirect(page, timeout = 20000, clientSide = false) {
+  const initial = await getCurrentUrl(page, clientSide);
   try {
     await waitUntil(async () => {
-      const current = await getCurrentUrl(page);
+      const current = await getCurrentUrl(page, clientSide);
       return current !== initial;
     }, `waiting for redirect from ${initial}`, timeout, 1000);
   } catch (e) {
     if (e && e.timeout) {
-      const current = await getCurrentUrl(page);
+      const current = await getCurrentUrl(page, clientSide);
       e.lastUrl = current;
     }
     throw e;

--- a/src/scrapers/base-scraper.js
+++ b/src/scrapers/base-scraper.js
@@ -139,7 +139,7 @@ class BaseScraper {
       await waitForNavigation(this.page);
     }
 
-    const current = await getCurrentUrl(this.page);
+    const current = await getCurrentUrl(this.page, true);
     const loginResult = getKeyByValue(loginOptions.possibleResults, current);
     return handleLoginResult(this, loginResult);
   }


### PR DESCRIPTION
There was a problem in the way we check current url, may be related to https://github.com/GoogleChrome/puppeteer/issues/1325.
Made client side check of url optional and refrained from using it in `LeumiCardScraper`.

fixes #62 