### PR TITLE
Refactor sortTransactionsByDate

### DIFF
--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import orderBy from 'lodash/orderBy';
+import _ from 'lodash';
 
 import { NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE } from '../constants';
 
@@ -32,7 +32,7 @@ export function fixInstallments(txns) {
 }
 
 export function sortTransactionsByDate(txns) {
-  return orderBy(txns, ['date']);
+  return _.sortBy(txns, ['date']);
 }
 
 export function filterOldTransactions(txns, startMoment, combineInstallments) {

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import orderBy from 'lodash/orderBy';
+import _ from 'lodash';
 
 import { NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE } from '../constants';
 
@@ -32,7 +32,7 @@ export function fixInstallments(txns) {
 }
 
 export function sortTransactionsByDate(txns) {
-  return orderBy(txns, 'date', 'asc');
+  return _.orderBy(txns, 'date', 'asc');
 }
 
 export function filterOldTransactions(txns, startMoment, combineInstallments) {

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import _ from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 import { NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE } from '../constants';
 
@@ -32,7 +32,7 @@ export function fixInstallments(txns) {
 }
 
 export function sortTransactionsByDate(txns) {
-  return _.orderBy(txns, 'date', 'asc');
+  return orderBy(txns, ['date']);
 }
 
 export function filterOldTransactions(txns, startMoment, combineInstallments) {

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -1,4 +1,6 @@
 import moment from 'moment';
+import orderBy from 'lodash/orderBy';
+
 import { NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE } from '../constants';
 
 function isNormalTransaction(txn) {
@@ -30,15 +32,7 @@ export function fixInstallments(txns) {
 }
 
 export function sortTransactionsByDate(txns) {
-  const cloned = Array.from(txns);
-  cloned.sort((txn1, txn2) => {
-    if (txn1.date.getTime() === txn2.date.getTime()) {
-      return 0;
-    }
-    return txn1.date < txn2.date ? -1 : 1;
-  });
-
-  return cloned;
+  return orderBy(txns, 'date', 'asc');
 }
 
 export function filterOldTransactions(txns, startMoment, combineInstallments) {


### PR DESCRIPTION
This PR refactor sortTransactionsByDate to use lodash.orderBy for readability
