### PR TITLE
Convert NIS to ILS

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ export const INSTALLMENTS_TXN_TYPE = 'installments';
 
 export const SHEKEL_CURRENCY_SYMBOL = '₪';
 export const SHEKEL_CURRENCY_KEYWORD = 'ש"ח';
+export const ALT_SHEKEL_CURRENCY = 'NIS';
 export const SHEKEL_CURRENCY = 'ILS';
 
 export const DOLLAR_CURRENCY_SYMBOL = '$';

--- a/src/scrapers/base-isracard-amex.js
+++ b/src/scrapers/base-isracard-amex.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
-import { SCRAPE_PROGRESS_TYPES, NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE, SHEKEL_CURRENCY_KEYWORD, SHEKEL_CURRENCY } from '../constants';
+import { SCRAPE_PROGRESS_TYPES, NORMAL_TXN_TYPE, INSTALLMENTS_TXN_TYPE, SHEKEL_CURRENCY_KEYWORD, SHEKEL_CURRENCY, ALT_SHEKEL_CURRENCY } from '../constants';
 import getAllMonthMoments from '../helpers/dates';
 import { fixInstallments, filterOldTransactions } from '../helpers/transactions';
 
@@ -59,7 +59,7 @@ function getTransactionsUrl(servicesUrl, monthMoment) {
 }
 
 function convertCurrency(currencyStr) {
-  if (currencyStr === SHEKEL_CURRENCY_KEYWORD) {
+  if (currencyStr === SHEKEL_CURRENCY_KEYWORD || currencyStr === ALT_SHEKEL_CURRENCY) {
     return SHEKEL_CURRENCY;
   }
   return currencyStr;


### PR DESCRIPTION
I've noticed that some of my Isracard transactions are is NIS.
Mostly those made with Paypal, but I believe that it all the transactions that made online with Shekels.

This PR converts `NIS` to `ILS` for Isracard
and introduces a new constant: `ALT_SHEKEL_CURRENCY` 