### PR TITLE
Implement multiple login results 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,10 @@ Unless you plan to override the entire `login()` function, You can override this
 ```node
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = '<SUCCESS_URL>';
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = '<INVALID_PASSWORD_URL>';
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = '<CHANGE_PASSWORD_URL>';
+  // in case of multiple possible login results, add them to the arrays as items
+  urls[LOGIN_RESULT.SUCCESS] = ['<SUCCESS_URL>'];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = ['<INVALID_PASSWORD_URL>'];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = ['<CHANGE_PASSWORD_URL>'];
   return urls;
 }
 

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -9,7 +9,7 @@ const VIEWPORT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 768;
 
 function getKeyByValue(object, value) {
-  return Object.keys(object).find(key => object[key] === value);
+  return Object.keys(object).find(key => object[key].indexOf(value) > -1);
 }
 
 function handleLoginResult(scraper, loginResult) {

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -9,7 +9,7 @@ const VIEWPORT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 768;
 
 function getKeyByValue(object, value) {
-  return Object.keys(object).find(key => object[key].indexOf(value) > -1);
+  return Object.keys(object).find(key => object[key].includes(value));
 }
 
 function handleLoginResult(scraper, loginResult) {

--- a/src/scrapers/discount.js
+++ b/src/scrapers/discount.js
@@ -68,9 +68,9 @@ async function navigateOrErrorLabel(page) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`;
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;
 }
 

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -65,8 +65,8 @@ async function fetchAccountData(page, options) {
 function getPossibleLoginResults() {
   const urls = {};
   urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/portalserver/HomePage`, `${BASE_URL}/ng-portals-bt/rb/he/homepage`];
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`;
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = `${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`;
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`];
   return urls;
 }
 

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
-import { waitForRedirect } from '../helpers/navigation';
+import { waitForRedirect, getCurrentUrl } from '../helpers/navigation';
 import { NORMAL_TXN_TYPE } from '../constants';
 import { fetchGetWithinPage } from '../helpers/fetch';
 
@@ -25,8 +25,10 @@ function convertTransactions(txns) {
 }
 
 async function fetchAccountData(page, options) {
-  const apiSiteUrl = `${BASE_URL}/ServerServices`;
-  const accountDataUrl = `${apiSiteUrl}/general/accounts`;
+  const currentUrl = await getCurrentUrl(page, true);
+  const subfolder = (currentUrl.includes('portalserver')) ? 'portalserver' : 'ssb';
+  const apiSiteUrl = `${BASE_URL}/${subfolder}`;
+  const accountDataUrl = `${BASE_URL}/ServerServices/general/accounts`;
   const accountInfo = await fetchGetWithinPage(page, accountDataUrl);
   const accountNumber = `${accountInfo[0].bankNumber}-${accountInfo[0].branchNumber}-${accountInfo[0].accountNumber}`;
 
@@ -62,7 +64,7 @@ async function fetchAccountData(page, options) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/portalserver/HomePage`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/portalserver/HomePage`, `${BASE_URL}/ng-portals-bt/rb/he/homepage`];
   urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`;
   urls[LOGIN_RESULT.CHANGE_PASSWORD] = `${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`;
   return urls;

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -245,8 +245,8 @@ async function getAccountData(page, options) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/Registred/HomePage.aspx`;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/Registred/HomePage.aspx`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`];
   return urls;
 }
 


### PR DESCRIPTION
Recently, I noticed Bank Hapoalim website home page and subfolders have been different for time to time. It used to be https://login.bankhapoalim.co.il/portalserver/HomePage, but mostly recently https://login.bankhapoalim.co.il//ng-portals-bt/rb/he/homepage.
Besides that, the api urls has been changed as well (from `${BASE_URL}/portalserver`  to `${BASE_URL}/ssb`. I don't know the nature of this change, maybe it's just an A/B testing, but it failed the scarper a lot lately.

So I updated `base-scraper-with-browser.js` to validate `possibleResults` served in arrays and changed `possibleResults[LOGIN_RESULT.SUCCESS]` of `HapoalimScarper` to be array of the current possibilities. It doesn't supposed to affect non-array `possibleResults` members.
Besides that, the `fetchAccountData` function is now handling the different possibilities of the API URL by the current URL of the page entity.

I guess my coding style is not top notch, feel comfortable to change it as far as you want.