### PR TITLE
add bank leumi scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # NPM package related
 lib/
+
+# IDEs
+.idea

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ const credentials = {
 ```
 This scraper supports fetching transaction from up to one year.
 
+## Bank Leumi scraper
+This scraper expects the following credentials object:
+```node
+const credentials = {
+  username: <user name>,
+  password: <user password>
+};
+```
+This scraper supports fetching transaction from up to one year.
+
 ## Discount scraper
 This scraper expects the following credentials object:
 ```node

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -5,6 +5,10 @@ export const SCRAPERS = {
     name: 'Bank Hapoalim',
     loginFields: ['userCode', PASSWORD_FIELD],
   },
+  leumi: {
+    name: 'Bank Leumi',
+    loginFields: ['username', PASSWORD_FIELD],
+  },
   discount: {
     name: 'Discount Bank',
     loginFields: ['id', PASSWORD_FIELD, 'num'],

--- a/src/helpers/elements-interactions.js
+++ b/src/helpers/elements-interactions.js
@@ -3,18 +3,11 @@ async function waitUntilElementFound(page, elementSelector, onlyVisible = false,
 }
 
 async function fillInput(page, inputSelector, inputValue) {
-  await page.$eval(inputSelector, (input) => { input.value = ''; }); // eslint-disable-line no-param-reassign
+  await page.$eval(inputSelector, (input) => {
+    const inputElement = input;
+    inputElement.value = '';
+  });
   await page.type(inputSelector, inputValue);
-}
-
-async function fillInputs(page, fields) {
-  const modified = [...fields];
-  const input = modified.shift();
-  await fillInput(page, input.selector, input.value);
-  if (modified.length) {
-    return fillInputs(page, modified);
-  }
-  return null;
 }
 
 async function clickButton(page, buttonSelector) {
@@ -26,4 +19,4 @@ async function dropdownSelect(page, selectSelector, value) {
   await page.select(selectSelector, value);
 }
 
-export { waitUntilElementFound, fillInput, clickButton, fillInputs, dropdownSelect };
+export { waitUntilElementFound, fillInput, clickButton, dropdownSelect };

--- a/src/helpers/elements-interactions.js
+++ b/src/helpers/elements-interactions.js
@@ -3,7 +3,18 @@ async function waitUntilElementFound(page, elementSelector, onlyVisible = false,
 }
 
 async function fillInput(page, inputSelector, inputValue) {
+  await page.$eval(inputSelector, (input) => { input.value = ''; }); // eslint-disable-line no-param-reassign
   await page.type(inputSelector, inputValue);
+}
+
+async function fillInputs(page, fields) {
+  const modified = [...fields];
+  const input = modified.shift();
+  await fillInput(page, input.selector, input.value);
+  if (modified.length) {
+    return fillInputs(page, modified);
+  }
+  return null;
 }
 
 async function clickButton(page, buttonSelector) {
@@ -11,4 +22,8 @@ async function clickButton(page, buttonSelector) {
   await button.click();
 }
 
-export { waitUntilElementFound, fillInput, clickButton };
+async function dropdownSelect(page, selectSelector, value) {
+  await page.select(selectSelector, value);
+}
+
+export { waitUntilElementFound, fillInput, clickButton, fillInputs, dropdownSelect };

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -9,7 +9,20 @@ const VIEWPORT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 768;
 
 function getKeyByValue(object, value) {
-  return Object.keys(object).find(key => object[key].includes(value));
+  return Object.keys(object).find((key) => {
+    const compareTo = object[key];
+    let result = false;
+
+    if (compareTo instanceof RegExp) {
+      result = compareTo.test(value);
+    } else if (compareTo instanceof Array) {
+      result = compareTo.includes(value);
+    } else {
+      result = value === compareTo;
+    }
+
+    return result;
+  });
 }
 
 function handleLoginResult(scraper, loginResult) {

--- a/src/scrapers/factory.js
+++ b/src/scrapers/factory.js
@@ -1,4 +1,5 @@
 import HapoalimScraper from './hapoalim';
+import LeumiScraper from './leumi';
 import DiscountScraper from './discount';
 import LeumiCardScraper from './leumi-card';
 import VisaCalScraper from './visa-cal';
@@ -9,6 +10,8 @@ export default function createScraper(options) {
   switch (options.companyId) {
     case 'hapoalim':
       return new HapoalimScraper(options);
+    case 'leumi':
+      return new LeumiScraper(options);
     case 'discount':
       return new DiscountScraper(options);
     case 'visaCal':

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -1,0 +1,176 @@
+import moment from 'moment';
+import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
+import { dropdownSelect, fillInput, clickButton, waitUntilElementFound } from '../helpers/elements-interactions';
+import { waitForNavigation } from '../helpers/navigation';
+import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE } from '../constants';
+
+const BASE_URL = 'https://hb2.bankleumi.co.il/';
+const DATE_FORMAT = 'DD/MM/YY';
+
+function getTransactionsUrl() {
+  return `${BASE_URL}/ebanking/Accounts/ExtendedActivity.aspx?WidgetPar=1#/`;
+}
+
+function getPossibleLoginResults() {
+  const urls = {};
+  urls[LOGIN_RESULT.SUCCESS] = /ebanking\/SO\/SPA.aspx/;
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = /InternalSite\/CustomUpdate\/leumi\/LoginPage.ASP/;
+  // urls[LOGIN_RESULT.CHANGE_PASSWORD] = ``; // TODO should wait until my password expires
+  return urls;
+}
+
+function createLoginFields(credentials) {
+  return [
+    { selector: '#wtr_uid', value: credentials.username },
+    { selector: '#wtr_password', value: credentials.password },
+  ];
+}
+
+function getAmountData(amountStr) {
+  const amountStrCopy = amountStr.replace(',', '');
+  const amount = parseFloat(amountStrCopy);
+  const currency = SHEKEL_CURRENCY;
+
+  return {
+    amount,
+    currency,
+  };
+}
+
+function convertTransactions(txns) {
+  return txns.map((txn) => {
+    const txnDate = moment(txn.date, DATE_FORMAT).toISOString();
+
+    const credit = getAmountData(txn.credit).amount;
+    const debit = getAmountData(txn.debit).amount;
+    const amount = (Number.isNaN(credit) ? 0 : credit) - (Number.isNaN(debit) ? 0 : debit);
+    return {
+      type: NORMAL_TXN_TYPE,
+      identifier: txn.reference ? parseInt(txn.reference, 10) : null,
+      date: txnDate,
+      processedDate: txnDate,
+      originalAmount: amount,
+      originalCurrency: SHEKEL_CURRENCY,
+      chargedAmount: amount,
+      description: txn.description,
+      /* memo: txn.memo, TODO add this line to export transaction memo */
+    };
+  });
+}
+
+async function fetchTransactionsForAccount(page, startDate) {
+  // TODO provide actual start date
+  await dropdownSelect(page, 'select#ddlTransactionPeriod', '004');
+  await waitUntilElementFound(page, 'select#ddlTransactionPeriod');
+  await fillInput(
+    page,
+    'input#dtFromDate_textBox',
+    startDate.format('DD/MM/YY'),
+  );
+  await clickButton(page, 'input#btnDisplayDates');
+  await waitForNavigation(page);
+  await waitUntilElementFound(page, 'table#WorkSpaceBox table#ctlActivityTable');
+  await clickButton(page, 'a#lnkCtlExpandAll');
+
+  const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
+    return $(option).text(); // eslint-disable-line no-undef
+  });
+
+  const accountNumber = selectedSnifAccount.replace('/', '_');
+
+  const tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
+    return tds.map(td =>
+      ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+  });
+
+  const txns = [];
+  for (const element of tdsValues) {
+    if (element.classList.includes('ExtendedActivityColumnDate')) {
+      const newTransaction = {};
+      newTransaction.date = (element.innerText || '').trim();
+      txns.push(newTransaction);
+    } else if (element.classList.includes('ActivityTableColumn1LTR')
+        || element.classList.includes('ActivityTableColumn1')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.description = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('ReferenceNumberUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.reference = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('AmountDebitUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.debit = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('AmountCreditUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.credit = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('number_column')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.balance = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('tdDepositRowAdded')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.memo = element.innerText;
+      txns.push(changedTransaction);
+    }
+  }
+
+  return {
+    accountNumber,
+    txns: convertTransactions(txns),
+  };
+}
+
+async function fetchTransactions(page, startDate) {
+  // TODO need to extend to support multiple accounts and foreign accounts
+  return [await fetchTransactionsForAccount(page, startDate)];
+}
+
+async function getAccountData(page, options) {
+  const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
+  const startDate = options.startDate || defaultStartMoment.toDate();
+  const startMoment = moment.max(defaultStartMoment, moment(startDate));
+
+
+  const url = getTransactionsUrl();
+  await page.goto(url);
+
+  const accounts = await fetchTransactions(page, startMoment);
+
+  return {
+    success: true,
+    accounts,
+  };
+}
+
+async function waitForPostLogin(page) {
+  // TODO replace 'div.leumi-container' with wait for SOA page
+  // TODO check for condition to provide new password
+  return Promise.race([
+    waitUntilElementFound(page, 'div.leumi-container', true),
+    waitUntilElementFound(page, '#loginErrMsg', true),
+  ]);
+}
+
+class LeumiScraper extends BaseScraperWithBrowser {
+  getLoginOptions(credentials) {
+    return {
+      loginUrl: `${BASE_URL}`,
+      fields: createLoginFields(credentials),
+      submitButtonSelector: '#enter',
+      postAction: async () => waitForPostLogin(this.page),
+      possibleResults: getPossibleLoginResults(),
+    };
+  }
+
+  async fetchData() {
+    return getAccountData(this.page, this.options);
+  }
+}
+
+export default LeumiScraper;

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -59,7 +59,6 @@ function convertTransactions(txns) {
 }
 
 async function fetchTransactionsForAccount(page, startDate) {
-  // TODO provide actual start date
   await dropdownSelect(page, 'select#ddlTransactionPeriod', '004');
   await waitUntilElementFound(page, 'select#ddlTransactionPeriod');
   await fillInput(
@@ -136,7 +135,6 @@ async function getAccountData(page, options) {
   const startDate = options.startDate || defaultStartMoment.toDate();
   const startMoment = moment.max(defaultStartMoment, moment(startDate));
 
-
   const url = getTransactionsUrl();
   await page.goto(url);
 
@@ -149,7 +147,6 @@ async function getAccountData(page, options) {
 }
 
 async function waitForPostLogin(page) {
-  // TODO replace 'div.leumi-container' with wait for SOA page
   // TODO check for condition to provide new password
   return Promise.race([
     waitUntilElementFound(page, 'div.leumi-container', true),

--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -10,7 +10,8 @@ import {
   SHEKEL_CURRENCY_SYMBOL,
   SHEKEL_CURRENCY,
   DOLLAR_CURRENCY_SYMBOL,
-  DOLLAR_CURRENCY } from '../constants';
+  DOLLAR_CURRENCY,
+} from '../constants';
 import { fetchGet, fetchPost } from '../helpers/fetch';
 import { fixInstallments, sortTransactionsByDate, filterOldTransactions } from '../helpers/transactions';
 


### PR DESCRIPTION
This PR contains a new scraper for bank Leumi. 

This PR also contains the following changes/additions:
- extended login completed check - support RexExp to validate navigated url. This change was added since the urls of bank Leumi contain custom data per browser session
- `fillInput()` now cleans the content of the field before it types the new value
- `dropdownSelect()` was added to select value in input of type select

There are some things to be added later after this PR will be merged:
- multiple accounts in bank Leumi (I couldn't develop it since I only have one account)
- foreign account (I couldn't develop it since I don't have such an account)
- missing login completed check for password expired. I recently changed my password so it will take a while till I will see this scenario.

And some final issues to discuss about not related directly to this PR:
- export memo field was commented following eshaham/israeli-bank-scrapers#83
- imho there is a discrepancy between the type of the date as mentioned in file [contributing.md](https://github.com/eshaham/israeli-bank-scrapers/blob/master/CONTRIBUTING.md#overriding-fetchdata) and the actual values returned by all scrapers. The type should be date yet the scrapers return `moment(...).toISOString()` which is of type string. I did the same to be persist with other scrapers. 