### PR TITLE
fix last comment from pull request 90

### DIFF
--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -72,7 +72,7 @@ async function fetchTransactionsForAccount(page, startDate) {
   await clickButton(page, 'a#lnkCtlExpandAll');
 
   const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
-    return $(option).text(); // eslint-disable-line no-undef
+    return (option.innerText || '').trim().replace(/&lrm;|\u200E/gi, '');
   });
 
   const accountNumber = selectedSnifAccount.replace('/', '_');


### PR DESCRIPTION
## Overview
remove left to right mark from account number and use simple DOM manipulation instead of jQuery

I noticed that the account number is padded with &lrm; markup. So during this PR I already removed it from the resulted account number.

----

## Out of pull request scope
@eshaham note that line 78 `const accountNumber = selectedSnifAccount.replace('/', '_');` exists only to allow [israeli-ynab-updater](https://github.com/eshaham/israeli-ynab-updater) to work with the new Leumi scraper. 
In Bank Leumi the account number includes symbol '/' (for example 933-507369/26). but since this is the first institude that uses this symbol, in YNAB  updater the exported csv file name is handling that symbol incorrectly - see the below example:

for value `933-507369/26` a csv file will be created in path `Users/es/Downloads/Bank Leumi (933-507369/26).csv` (meaning parent folder `Bank Leumi (933-507369` and file named `26).csv`). I think we should consider reverting this line once you will handle it in YNAB project. wdyt?
