### PR TITLE
Re-use existing tab when launching

### DIFF
--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -63,7 +63,12 @@ class BaseScraperWithBrowser extends BaseScraper {
       env = Object.assign({ DEBUG: '*' }, process.env);
     }
     this.browser = await puppeteer.launch({ env, headless: !this.options.showBrowser });
-    this.page = await this.browser.newPage();
+    const pages = await this.browser.pages();
+    if (pages.length) {
+      [this.page] = pages;
+    } else {
+      this.page = await this.browser.newPage();
+    }
     await this.page.setViewport({
       width: VIEWPORT_WIDTH,
       height: VIEWPORT_HEIGHT,


### PR DESCRIPTION
When launched in a non-headless mode, one can see a second tab opening, instead of using the first one. This PR re-uses the first open tab upon launching.