### PR TITLE
Add account summary property to Hapoalim scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # NPM package related
 lib/
+
+# IDEs
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,10 @@ Unless you plan to override the entire `login()` function, You can override this
 ```node
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = '<SUCCESS_URL>';
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = '<INVALID_PASSWORD_URL>';
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = '<CHANGE_PASSWORD_URL>';
+  // in case of multiple possible login results, add them to the arrays as items
+  urls[LOGIN_RESULT.SUCCESS] = ['<SUCCESS_URL>'];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = ['<INVALID_PASSWORD_URL>'];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = ['<CHANGE_PASSWORD_URL>'];
   return urls;
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,8 @@ You can override this async function however way you want, as long as your retur
     txns: [{
       type: string, // can be either 'normal' or 'installments'
       identifier: int, // only if exists
-      date: Date,
-      processedDate: Date,
+      date: string, // ISO date string
+      processedDate: string, // ISO date string
       originalAmount: double,
       originalCurrency: string,
       chargedAmount: double,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ const credentials = {
 ```
 This scraper supports fetching transaction from up to one year.
 
+## Bank Leumi scraper
+This scraper expects the following credentials object:
+```node
+const credentials = {
+  username: <user name>,
+  password: <user password>
+};
+```
+This scraper supports fetching transaction from up to one year.
+
 ## Discount scraper
 This scraper expects the following credentials object:
 ```node

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The structure of the result object is as follows:
     txns: [{
       type: string, // can be either 'normal' or 'installments'
       identifier: int, // only if exists
-      date: Date,
-      processedDate: Date,
+      date: string, // ISO date string
+      processedDate: string, // ISO date string
       originalAmount: double,
       originalCurrency: string,
       chargedAmount: double,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Israeli Bank Scrapers - Get closer to your own data
 What you can find here is scrapers for all major Israeli banks and credit card companies. That's the plan at least.
 Currently only the following banks are supported:
 - Bank Hapoalim (thanks [@sebikaplun](https://github.com/sebikaplun))
+- Leumi Bank (thanks [@esakal](https://github.com/esakal))
 - Discount Bank
 - Visa Cal (thanks [@nirgin](https://github.com/nirgin))
 - Leumi Card

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "israeli-bank-scrapers",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
+      "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -42,7 +42,7 @@
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -83,9 +83,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -163,7 +163,7 @@
         "convert-source-map": "1.5.0",
         "fs-readdir-recursive": "1.0.0",
         "glob": "7.1.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
         "slash": "1.0.0",
@@ -201,7 +201,7 @@
             "convert-source-map": "1.5.0",
             "debug": "2.6.8",
             "json5": "0.5.1",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4",
             "path-is-absolute": "1.0.1",
             "private": "0.1.7",
@@ -220,7 +220,7 @@
             "babel-types": "6.26.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "source-map": "0.5.6",
             "trim-right": "1.0.1"
           }
@@ -235,7 +235,7 @@
             "babel-runtime": "6.26.0",
             "core-js": "2.5.0",
             "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "source-map-support": "0.4.15"
           },
@@ -268,7 +268,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-traverse": {
@@ -285,7 +285,7 @@
             "debug": "2.6.8",
             "globals": "9.18.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-types": {
@@ -296,7 +296,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -357,7 +357,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -378,7 +378,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -452,7 +452,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -473,7 +473,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -597,7 +597,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-code-frame": {
@@ -631,7 +631,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-traverse": {
@@ -648,7 +648,7 @@
             "debug": "2.6.8",
             "globals": "9.18.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-types": {
@@ -659,7 +659,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -806,7 +806,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-traverse": {
@@ -823,7 +823,7 @@
             "debug": "2.6.8",
             "globals": "9.18.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "babel-types": {
@@ -834,7 +834,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -1078,7 +1078,7 @@
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
         "babylon": "6.17.4",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-traverse": {
@@ -1095,7 +1095,7 @@
         "debug": "2.6.8",
         "globals": "9.18.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "babel-types": {
@@ -1106,7 +1106,7 @@
       "requires": {
         "babel-runtime": "6.25.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1378,14 +1378,6 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -1415,21 +1407,21 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
-      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
+      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.22.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.2",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.2",
+        "espree": "3.5.4",
         "esquery": "1.0.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
@@ -1440,10 +1432,10 @@
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -1466,23 +1458,23 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.3.0"
           }
         },
         "debug": {
@@ -1510,12 +1502,12 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1530,13 +1522,24 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -1550,19 +1553,19 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
         "debug": "2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
+        "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
-        "lodash.cond": "4.5.2",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0"
       },
@@ -1591,7 +1594,7 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
+        "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
     },
@@ -1602,12 +1605,12 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.5.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1627,13 +1630,12 @@
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -1719,9 +1721,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2823,9 +2825,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "home-or-tmp": {
@@ -2866,7 +2868,8 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.7",
@@ -2901,12 +2904,12 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -2923,23 +2926,23 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.3.0"
           }
         },
         "strip-ansi": {
@@ -2952,12 +2955,12 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3115,11 +3118,6 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3148,12 +3146,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "4.0.0"
       }
     },
@@ -3231,15 +3229,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -3288,9 +3280,9 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
@@ -3316,9 +3308,9 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -3345,13 +3337,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
+      "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -3362,7 +3350,7 @@
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -3411,7 +3399,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -3458,10 +3446,13 @@
       }
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -3469,8 +3460,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -3622,9 +3619,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
-      "integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.1.tgz",
+      "integrity": "sha1-rb8l5J9e8DRDwQq44JqVTKDHv+4=",
       "requires": {
         "debug": "2.6.8",
         "extract-zip": "1.6.6",
@@ -3982,24 +3979,35 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "sprintf-js": {
@@ -4078,39 +4086,39 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4188,13 +4196,13 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -36,17 +36,17 @@
     "babel-plugin-transform-es2015-block-scoping": "^6.26.0",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
-    "eslint": "^4.16.0",
+    "eslint": "^4.18.2",
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "^2.9.0",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "build-url": "^1.0.10",
-    "lodash": "^4.17.4",
-    "moment": "^2.20.1",
-    "node-fetch": "^1.7.3",
+    "lodash": "^4.17.5",
+    "moment": "^2.21.0",
+    "node-fetch": "^2.1.1",
     "puppeteer": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "israeli-bank-scrapers",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Provide scrapers for all major Israeli banks and credit card companies",
   "engines": {
     "node": ">= 8.2.1",

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -5,6 +5,10 @@ export const SCRAPERS = {
     name: 'Bank Hapoalim',
     loginFields: ['userCode', PASSWORD_FIELD],
   },
+  leumi: {
+    name: 'Bank Leumi',
+    loginFields: ['username', PASSWORD_FIELD],
+  },
   discount: {
     name: 'Discount Bank',
     loginFields: ['id', PASSWORD_FIELD, 'num'],

--- a/src/helpers/elements-interactions.js
+++ b/src/helpers/elements-interactions.js
@@ -3,6 +3,10 @@ async function waitUntilElementFound(page, elementSelector, onlyVisible = false,
 }
 
 async function fillInput(page, inputSelector, inputValue) {
+  await page.$eval(inputSelector, (input) => {
+    const inputElement = input;
+    inputElement.value = '';
+  });
   await page.type(inputSelector, inputValue);
 }
 
@@ -11,4 +15,8 @@ async function clickButton(page, buttonSelector) {
   await button.click();
 }
 
-export { waitUntilElementFound, fillInput, clickButton };
+async function dropdownSelect(page, selectSelector, value) {
+  await page.select(selectSelector, value);
+}
+
+export { waitUntilElementFound, fillInput, clickButton, dropdownSelect };

--- a/src/helpers/navigation.js
+++ b/src/helpers/navigation.js
@@ -1,15 +1,19 @@
 import waitUntil from './waiting';
 
-const NAVIGATION_ERRORS = {
+export const NAVIGATION_ERRORS = {
   TIMEOUT: 'timeout',
   GENERIC: 'generic',
 };
 
-async function waitForNavigation(page) {
-  await page.waitForNavigation();
+export async function waitForNavigation(page, options) {
+  await page.waitForNavigation(options);
 }
 
-async function getCurrentUrl(page, clientSide = false) {
+export async function waitForNavigationAndDomLoad(page) {
+  await waitForNavigation(page, { waitUntil: 'domcontentloaded' });
+}
+
+export async function getCurrentUrl(page, clientSide = false) {
   if (clientSide) {
     return page.evaluate(() => window.location.href);
   }
@@ -17,7 +21,7 @@ async function getCurrentUrl(page, clientSide = false) {
   return page.url();
 }
 
-async function waitForRedirect(page, timeout = 20000, clientSide = false) {
+export async function waitForRedirect(page, timeout = 20000, clientSide = false) {
   const initial = await getCurrentUrl(page, clientSide);
   try {
     await waitUntil(async () => {
@@ -32,5 +36,3 @@ async function waitForRedirect(page, timeout = 20000, clientSide = false) {
     throw e;
   }
 }
-
-export { waitForNavigation, waitForRedirect, getCurrentUrl, NAVIGATION_ERRORS };

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -63,7 +63,12 @@ class BaseScraperWithBrowser extends BaseScraper {
       env = Object.assign({ DEBUG: '*' }, process.env);
     }
     this.browser = await puppeteer.launch({ env, headless: !this.options.showBrowser });
-    this.page = await this.browser.newPage();
+    const pages = await this.browser.pages();
+    if (pages.length) {
+      [this.page] = pages;
+    } else {
+      this.page = await this.browser.newPage();
+    }
     await this.page.setViewport({
       width: VIEWPORT_WIDTH,
       height: VIEWPORT_HEIGHT,

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -9,7 +9,20 @@ const VIEWPORT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 768;
 
 function getKeyByValue(object, value) {
-  return Object.keys(object).find(key => object[key].includes(value));
+  return Object.keys(object).find((key) => {
+    const compareTo = object[key];
+    let result = false;
+
+    if (compareTo instanceof RegExp) {
+      result = compareTo.test(value);
+    } else if (compareTo instanceof Array) {
+      result = compareTo.includes(value);
+    } else {
+      result = value === compareTo;
+    }
+
+    return result;
+  });
 }
 
 function handleLoginResult(scraper, loginResult) {

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -9,7 +9,7 @@ const VIEWPORT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 768;
 
 function getKeyByValue(object, value) {
-  return Object.keys(object).find(key => object[key] === value);
+  return Object.keys(object).find(key => object[key].includes(value));
 }
 
 function handleLoginResult(scraper, loginResult) {

--- a/src/scrapers/discount.js
+++ b/src/scrapers/discount.js
@@ -68,9 +68,9 @@ async function navigateOrErrorLabel(page) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`;
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;
 }
 

--- a/src/scrapers/factory.js
+++ b/src/scrapers/factory.js
@@ -1,4 +1,5 @@
 import HapoalimScraper from './hapoalim';
+import LeumiScraper from './leumi';
 import DiscountScraper from './discount';
 import LeumiCardScraper from './leumi-card';
 import VisaCalScraper from './visa-cal';
@@ -9,6 +10,8 @@ export default function createScraper(options) {
   switch (options.companyId) {
     case 'hapoalim':
       return new HapoalimScraper(options);
+    case 'leumi':
+      return new LeumiScraper(options);
     case 'discount':
       return new DiscountScraper(options);
     case 'visaCal':

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
-import { waitForRedirect } from '../helpers/navigation';
+import { waitForRedirect, getCurrentUrl } from '../helpers/navigation';
 import { NORMAL_TXN_TYPE } from '../constants';
 import { fetchGetWithinPage } from '../helpers/fetch';
 
@@ -25,8 +25,10 @@ function convertTransactions(txns) {
 }
 
 async function fetchAccountData(page, options) {
-  const apiSiteUrl = `${BASE_URL}/ServerServices`;
-  const accountDataUrl = `${apiSiteUrl}/general/accounts`;
+  const currentUrl = await getCurrentUrl(page, true);
+  const subfolder = (currentUrl.includes('portalserver')) ? 'portalserver' : 'ssb';
+  const apiSiteUrl = `${BASE_URL}/${subfolder}`;
+  const accountDataUrl = `${BASE_URL}/ServerServices/general/accounts`;
   const accountsInfo = await fetchGetWithinPage(page, accountDataUrl);
 
   const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
@@ -66,9 +68,9 @@ async function fetchAccountData(page, options) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/portalserver/HomePage`;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`;
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = `${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/portalserver/HomePage`, `${BASE_URL}/ng-portals-bt/rb/he/homepage`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`];
   return urls;
 }
 

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -14,6 +14,7 @@ const NORMAL_TYPE_NAME = 'רגילה';
 const ATM_TYPE_NAME = 'חיוב עסקות מיידי';
 const INTERNET_SHOPPING_TYPE_NAME = 'אינטרנט/חו"ל';
 const INSTALLMENTS_TYPE_NAME = 'תשלומים';
+const MONTHLY_CHARGE_TYPE_NAME = 'חיוב חודשי';
 const ONE_MONTH_POSTPONED_TYPE_NAME = 'דחוי חודש';
 const TWO_MONTHS_POSTPONED_TYPE_NAME = 'דחוי חודשיים';
 
@@ -48,6 +49,7 @@ function getTransactionType(txnTypeStr) {
   switch (txnTypeStr.trim()) {
     case ATM_TYPE_NAME:
     case NORMAL_TYPE_NAME:
+    case MONTHLY_CHARGE_TYPE_NAME:
     case ONE_MONTH_POSTPONED_TYPE_NAME:
     case TWO_MONTHS_POSTPONED_TYPE_NAME:
     case INTERNET_SHOPPING_TYPE_NAME:

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -247,8 +247,8 @@ async function getAccountData(page, options) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = `${BASE_URL}/Registred/HomePage.aspx`;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = `${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`;
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/Registred/HomePage.aspx`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`];
   return urls;
 }
 

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -1,0 +1,173 @@
+import moment from 'moment';
+import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
+import { dropdownSelect, fillInput, clickButton, waitUntilElementFound } from '../helpers/elements-interactions';
+import { waitForNavigation } from '../helpers/navigation';
+import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE } from '../constants';
+
+const BASE_URL = 'https://hb2.bankleumi.co.il/';
+const DATE_FORMAT = 'DD/MM/YY';
+
+function getTransactionsUrl() {
+  return `${BASE_URL}/ebanking/Accounts/ExtendedActivity.aspx?WidgetPar=1#/`;
+}
+
+function getPossibleLoginResults() {
+  const urls = {};
+  urls[LOGIN_RESULT.SUCCESS] = /ebanking\/SO\/SPA.aspx/;
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = /InternalSite\/CustomUpdate\/leumi\/LoginPage.ASP/;
+  // urls[LOGIN_RESULT.CHANGE_PASSWORD] = ``; // TODO should wait until my password expires
+  return urls;
+}
+
+function createLoginFields(credentials) {
+  return [
+    { selector: '#wtr_uid', value: credentials.username },
+    { selector: '#wtr_password', value: credentials.password },
+  ];
+}
+
+function getAmountData(amountStr) {
+  const amountStrCopy = amountStr.replace(',', '');
+  const amount = parseFloat(amountStrCopy);
+  const currency = SHEKEL_CURRENCY;
+
+  return {
+    amount,
+    currency,
+  };
+}
+
+function convertTransactions(txns) {
+  return txns.map((txn) => {
+    const txnDate = moment(txn.date, DATE_FORMAT).toISOString();
+
+    const credit = getAmountData(txn.credit).amount;
+    const debit = getAmountData(txn.debit).amount;
+    const amount = (Number.isNaN(credit) ? 0 : credit) - (Number.isNaN(debit) ? 0 : debit);
+    return {
+      type: NORMAL_TXN_TYPE,
+      identifier: txn.reference ? parseInt(txn.reference, 10) : null,
+      date: txnDate,
+      processedDate: txnDate,
+      originalAmount: amount,
+      originalCurrency: SHEKEL_CURRENCY,
+      chargedAmount: amount,
+      description: txn.description,
+      /* memo: txn.memo, TODO add this line to export transaction memo */
+    };
+  });
+}
+
+async function fetchTransactionsForAccount(page, startDate) {
+  await dropdownSelect(page, 'select#ddlTransactionPeriod', '004');
+  await waitUntilElementFound(page, 'select#ddlTransactionPeriod');
+  await fillInput(
+    page,
+    'input#dtFromDate_textBox',
+    startDate.format('DD/MM/YY'),
+  );
+  await clickButton(page, 'input#btnDisplayDates');
+  await waitForNavigation(page);
+  await waitUntilElementFound(page, 'table#WorkSpaceBox table#ctlActivityTable');
+  await clickButton(page, 'a#lnkCtlExpandAll');
+
+  const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
+    return $(option).text(); // eslint-disable-line no-undef
+  });
+
+  const accountNumber = selectedSnifAccount.replace('/', '_');
+
+  const tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
+    return tds.map(td =>
+      ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+  });
+
+  const txns = [];
+  for (const element of tdsValues) {
+    if (element.classList.includes('ExtendedActivityColumnDate')) {
+      const newTransaction = {};
+      newTransaction.date = (element.innerText || '').trim();
+      txns.push(newTransaction);
+    } else if (element.classList.includes('ActivityTableColumn1LTR')
+        || element.classList.includes('ActivityTableColumn1')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.description = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('ReferenceNumberUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.reference = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('AmountDebitUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.debit = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('AmountCreditUniqeClass')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.credit = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('number_column')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.balance = element.innerText;
+      txns.push(changedTransaction);
+    } else if (element.classList.includes('tdDepositRowAdded')) {
+      const changedTransaction = txns.pop();
+      changedTransaction.memo = element.innerText;
+      txns.push(changedTransaction);
+    }
+  }
+
+  return {
+    accountNumber,
+    txns: convertTransactions(txns),
+  };
+}
+
+async function fetchTransactions(page, startDate) {
+  // TODO need to extend to support multiple accounts and foreign accounts
+  return [await fetchTransactionsForAccount(page, startDate)];
+}
+
+async function getAccountData(page, options) {
+  const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
+  const startDate = options.startDate || defaultStartMoment.toDate();
+  const startMoment = moment.max(defaultStartMoment, moment(startDate));
+
+  const url = getTransactionsUrl();
+  await page.goto(url);
+
+  const accounts = await fetchTransactions(page, startMoment);
+
+  return {
+    success: true,
+    accounts,
+  };
+}
+
+async function waitForPostLogin(page) {
+  // TODO check for condition to provide new password
+  return Promise.race([
+    waitUntilElementFound(page, 'div.leumi-container', true),
+    waitUntilElementFound(page, '#loginErrMsg', true),
+  ]);
+}
+
+class LeumiScraper extends BaseScraperWithBrowser {
+  getLoginOptions(credentials) {
+    return {
+      loginUrl: `${BASE_URL}`,
+      fields: createLoginFields(credentials),
+      submitButtonSelector: '#enter',
+      postAction: async () => waitForPostLogin(this.page),
+      possibleResults: getPossibleLoginResults(),
+    };
+  }
+
+  async fetchData() {
+    return getAccountData(this.page, this.options);
+  }
+}
+
+export default LeumiScraper;

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -72,7 +72,7 @@ async function fetchTransactionsForAccount(page, startDate) {
   await clickButton(page, 'a#lnkCtlExpandAll');
 
   const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
-    return option.innerText;
+    return (option.innerText || '').trim().replace(/&lrm;|\u200E/gi, '');
   });
 
   const accountNumber = selectedSnifAccount.replace('/', '_');

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -72,7 +72,7 @@ async function fetchTransactionsForAccount(page, startDate) {
   await clickButton(page, 'a#lnkCtlExpandAll');
 
   const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
-    return $(option).text(); // eslint-disable-line no-undef
+    return option.innerText;
   });
 
   const accountNumber = selectedSnifAccount.replace('/', '_');

--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -10,7 +10,8 @@ import {
   SHEKEL_CURRENCY_SYMBOL,
   SHEKEL_CURRENCY,
   DOLLAR_CURRENCY_SYMBOL,
-  DOLLAR_CURRENCY } from '../constants';
+  DOLLAR_CURRENCY,
+} from '../constants';
 import { fetchGet, fetchPost } from '../helpers/fetch';
 import { fixInstallments, sortTransactionsByDate, filterOldTransactions } from '../helpers/transactions';
 

--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -23,6 +23,7 @@ const WITHDRAWAL_TYPE_CODE = '7';
 const INSTALLMENTS_TYPE_CODE = '8';
 const CANCEL_TYPE_CODE = '25';
 const WITHDRAWAL_TYPE_CODE_2 = '27';
+const REFUND_TYPE_CODE_2 = '76';
 
 function getBankDebitsUrl(accountId) {
   const toDate = new Date();
@@ -60,6 +61,7 @@ function convertTransactionType(txnType) {
     case CANCEL_TYPE_CODE:
     case WITHDRAWAL_TYPE_CODE:
     case WITHDRAWAL_TYPE_CODE_2:
+    case REFUND_TYPE_CODE_2:
       return NORMAL_TXN_TYPE;
     case INSTALLMENTS_TYPE_CODE:
       return INSTALLMENTS_TXN_TYPE;


### PR DESCRIPTION
As detailed in issue #76, the scraper now adds a summary property to every account the scraper returns.
The summary structured like this:
```
{
  ...
  summary: {
    balance: double,
    creditLimit: double,
    creditUtilization: double,
    balanceCurrency: 'ILS',
  }
  ..
}
```
(It seems the branch was behind of master branch, and this PR adds all the commits committed since then, along with this commit. You can delete them if it needed).