### PR TITLE
fix transactions filter when not combining installments

### DIFF
--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -39,7 +39,7 @@ export function filterOldTransactions(txns, startMoment, combineInstallments) {
   return txns.filter((txn) => {
     const combineNeededAndInitialOrNormal =
       combineInstallments && (isNormalTransaction(txn) || isInitialInstallmentTransaction(txn));
-    return (!combineInstallments && startMoment.isSameOrBefore(txn.processedDate)) ||
+    return (!combineInstallments && startMoment.isSameOrBefore(txn.date)) ||
            (combineNeededAndInitialOrNormal && startMoment.isSameOrBefore(txn.date));
   });
 }


### PR DESCRIPTION
when `combineInstallments === false`, function `filterOldTransactions` filters transactions using the `processedDate` property.

This is causing the function to include transactions that were processed in a relevant month but were created in a previous month

see issue #109 for detailed information

closes #109