### PR TITLE
align transactions status across scrapers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,6 @@ export const NAVIGATION_ERRORS = {
 export const GENERAL_ERROR = 'GENERAL_ERROR';
 
 export const TRANSACTION_STATUS = {
-  COMPLETED: 'COMPLETED',
-  PENDING: 'PENDING',
+  COMPLETED: 'completed',
+  PENDING: 'pending',
 };

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
 import { dropdownSelect, fillInput, clickButton, waitUntilElementFound } from '../helpers/elements-interactions';
 import { waitForNavigation } from '../helpers/navigation';
-import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE } from '../constants';
+import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE, TRANSACTION_STATUS } from '../constants';
 
 const BASE_URL = 'https://hb2.bankleumi.co.il/';
 const DATE_FORMAT = 'DD/MM/YY';
@@ -72,7 +72,7 @@ async function extractCompletedTransactionsFromPage(page) {
 
   for (const element of tdsValues) {
     if (element.classList.includes('ExtendedActivityColumnDate')) {
-      const newTransaction = { status: 'completed' };
+      const newTransaction = { status: TRANSACTION_STATUS.COMPLETED };
       newTransaction.date = (element.innerText || '').trim();
       txns.push(newTransaction);
     } else if (element.classList.includes('ActivityTableColumn1LTR')
@@ -119,7 +119,7 @@ async function extractPendingTransactionsFromPage(page) {
 
   for (const element of tdsValues) {
     if (element.classList.includes('Colume1Width')) {
-      const newTransaction = { status: 'pending' };
+      const newTransaction = { status: TRANSACTION_STATUS.PENDING };
       newTransaction.date = (element.innerText || '').trim();
       txns.push(newTransaction);
     } else if (element.classList.includes('Colume2Width')) {


### PR DESCRIPTION
# Goals
- lower case the status values to align them to the [CONTRIBUTING.md](https://github.com/eshaham/israeli-bank-scrapers/blob/master/CONTRIBUTING.md) content
![image](https://user-images.githubusercontent.com/4751797/38782552-204fdbcc-40fe-11e8-90f4-b537a09a1f18.png)



- use constants values in Leumi scraper for transaction status
![image](https://user-images.githubusercontent.com/4751797/38782561-2eef513a-40fe-11e8-907f-6a92c9672b7a.png)

