### PR TITLE
fix scraping of Hapoalim from account that was transfered to a new snif

### DIFF
--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -42,7 +42,11 @@ export async function fetchGetWithinPage(page, url) {
       fetch(url, {
         credentials: 'include',
       }).then((result) => {
-        resolve(result.json());
+        if (result.status === 204) {
+          resolve(null);
+        } else {
+          resolve(result.json());
+        }
       }).catch((e) => {
         reject(e);
       });

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -55,7 +55,7 @@ async function fetchAccountData(page, options) {
     const txnsUrl = `${apiSiteUrl}/current-account/transactions?accountId=${accountNumber}&numItemsPerPage=150&retrievalEndDate=${endDateStr}&retrievalStartDate=${startDateStr}&sortCode=1`;
 
     const txnsResult = await fetchGetWithinPage(page, txnsUrl);
-    const txns = convertTransactions(txnsResult.transactions);
+    const txns = txnsResult ? convertTransactions(txnsResult.transactions) : [];
 
     accounts.push({
       accountNumber,


### PR DESCRIPTION
# Motivation
trying to scrape bank hapoalim with an account that was transfered between snifim. 

# Scenario
- User opens an account in bank hapoalim snif 111 and account 999999.
- In bank Hapoalim site the account will be shown as `12-111-999999`
- User later move to a new (pyshical) snif 222. 
- In bank Hapoalim site the account will be shown twice, both `12-111-999999` and `12-222-999999`
- trying to scrape the old account will result with http status 204

# Desired behavior (fixed in the PR)
- return 0 transactions for the old snif-account `12-111-999999`

# Actual behavior
- un-unhandled exception is thrown, stopping the scraping process.

