### PR TITLE
leumi-card: handle redirects during transaction scraping

### DIFF
--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -236,6 +236,10 @@ async function fetchTransactionsForMonth(browser, monthMoment) {
   const url = getTransactionsUrl(monthMoment);
   await page.goto(url);
 
+  if (page.url() !== url) {
+    throw new Error(`Error while trying to navigate to url ${url}`);
+  }
+
   const txns = await getCurrentTransactions(page);
   await page.close();
 


### PR DESCRIPTION
# Motivation
Detect server redirects when scraping leumi card transactions

# Technical information
When leumi site decide to redirect the user, the page url changes as seen below:
![image](https://user-images.githubusercontent.com/4751797/41202421-bf730414-6cd1-11e8-9ee1-22574010d08d.png)

In this change I'm verifying that the url of the page equals the url we navigated to.

I'm not sure if leumi-card has a use-case where the returned page is the same page but it holds a message indicating of a problem. once we will encounter such a scenario we will be able to handle it as-well.

fixes #112 