### PR TITLE
Hapoalim change password

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ Unless you plan to override the entire `login()` function, You can override this
 function getPossibleLoginResults() {
   const urls = {};
   // in case of multiple possible login results, add them to the arrays as items
-  urls[LOGIN_RESULT.SUCCESS] = ['<SUCCESS_URL>'];
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = ['<INVALID_PASSWORD_URL>'];
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = ['<CHANGE_PASSWORD_URL>'];
+  urls[LOGIN_RESULT.SUCCESS] = ['<SUCCESS_URL>' | <SUCCESS_REGEXP>];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = ['<INVALID_PASSWORD_URL>' | <INVALID_PASSWORD_REGEXP>];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = ['<CHANGE_PASSWORD_URL>' | <CHANGE_PASSWORD_REGEXP>];
   return urls;
 }
 

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -14,15 +14,15 @@ function getKeyByValue(object, value) {
     const compareTo = object[key];
     let result = false;
 
-    if (compareTo instanceof RegExp) {
-      result = compareTo.test(value);
-    } else if (compareTo instanceof Array) {
-      result = compareTo.includes(value);
-    } else {
-      result = value === compareTo;
-    }
+    result = compareTo.find((item) => {
+      if (item instanceof RegExp) {
+        return item.test(value);
+      }
 
-    return result;
+      return value === item;
+    });
+
+    return !!result;
   });
 }
 

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -127,7 +127,10 @@ function getPossibleLoginResults() {
   const urls = {};
   urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/portalserver/HomePage`, `${BASE_URL}/ng-portals-bt/rb/he/homepage`, `${BASE_URL}/ng-portals/rb/he/homepage`];
   urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`];
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [
+    `${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`,
+    /[.]co[.]il\/ABOUTTOEXPIRE\/START/i,
+  ];
   return urls;
 }
 

--- a/src/scrapers/hapoalim.js
+++ b/src/scrapers/hapoalim.js
@@ -129,7 +129,7 @@ function getPossibleLoginResults() {
   urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/AUTHENTICATE/LOGON?flow=AUTHENTICATE&state=LOGON&errorcode=1.6&callme=false`];
   urls[LOGIN_RESULT.CHANGE_PASSWORD] = [
     `${BASE_URL}/MCP/START?flow=MCP&state=START&expiredDate=null`,
-    /[.]co[.]il\/ABOUTTOEXPIRE\/START/i,
+    /\/ABOUTTOEXPIRE\/START/i,
   ];
   return urls;
 }

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -18,8 +18,8 @@ function getTransactionsUrl() {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = /ebanking\/SO\/SPA.aspx/;
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = /InternalSite\/CustomUpdate\/leumi\/LoginPage.ASP/;
+  urls[LOGIN_RESULT.SUCCESS] = [/ebanking\/SO\/SPA.aspx/];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [/InternalSite\/CustomUpdate\/leumi\/LoginPage.ASP/];
   // urls[LOGIN_RESULT.CHANGE_PASSWORD] = ``; // TODO should wait until my password expires
   return urls;
 }


### PR DESCRIPTION
# Overview
Bank hapoalim has another url that is used when password expires. 

## Current behavior
When getting the following page, the scraper return with status `undefined`
![image](https://user-images.githubusercontent.com/4751797/42127893-dd3988f6-7ca8-11e8-8212-f2877c7c2821.png)

## Modified behavior
The hapoalim scraper now recognize this page url.

# Technical
## Why using Regexp instead of string comparison
the url of this page is as followed: `https://login.bankhapoalim.co.il/ABOUTTOEXPIRE/START?flow=ABOUTTOEXPIRE&state=START&expiredDate=11072018`. The last property named `expiredDate` is dynamic and changes per user. So we need to be able to compare using regexp

## Why changing the base scraper functionality 
property `loginOptions.possibleResults` structure is hashmap and hapoalim already have a string comparison value for key `LOGIN_RESULT.CHANGE_PASSWORD`. I needed to modify the logic to allow passing in the array value both string and regexp. 



