### PR TITLE
fix undesired behavior of pupeteer for page.$$eval started since pupp…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,9 +7,16 @@
       "error",
       "ForInStatement",
       "LabeledStatement",
-      "WithStatement",
+      "WithStatement"
     ],
-    "operator-linebreak": ["error", "after"]
+    "operator-linebreak": ["error", "after"],
+    "max-len": ["error", 100, 2, {
+      "ignoreUrls": true,
+      "ignoreComments": true,
+      "ignoreRegExpLiterals": true,
+      "ignoreStrings": true,
+      "ignoreTemplateLiterals": true
+    }]
   },
   "globals": {
     "document": true,

--- a/src/helpers/elements-interactions.js
+++ b/src/helpers/elements-interactions.js
@@ -15,6 +15,20 @@ async function clickButton(page, buttonSelector) {
   await button.click();
 }
 
+async function pageEvalAll(page, selector, defaultResult, callback) {
+  let result = defaultResult;
+  try {
+    result = await page.$$eval(selector, callback);
+  } catch (e) {
+    // TODO temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until they will release a new version.
+    if (e.message.indexOf('Error: failed to find elements matching selector') !== 0) {
+      throw e;
+    }
+  }
+
+  return result;
+}
+
 async function dropdownSelect(page, selectSelector, value) {
   await page.select(selectSelector, value);
 }
@@ -24,4 +38,5 @@ export {
   fillInput,
   clickButton,
   dropdownSelect,
+  pageEvalAll,
 };

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -5,6 +5,7 @@ import {
   fillInput,
   clickButton,
   waitUntilElementFound,
+  pageEvalAll,
 } from '../helpers/elements-interactions';
 import { waitForNavigation } from '../helpers/navigation';
 import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE, TRANSACTION_STATUS } from '../constants';
@@ -66,24 +67,12 @@ function convertTransactions(txns) {
 
 async function extractCompletedTransactionsFromPage(page) {
   const txns = [];
-
-  let tdsValues;
-  try {
-    tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
-      return tds.map(td => ({
-        classList: td.getAttribute('class'),
-        innerText: td.innerText,
-      }));
-    });
-  } catch (e) {
-    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
-      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
-      // they will release a new version.
-      tdsValues = [];
-    } else {
-      throw e;
-    }
-  }
+  const tdsValues = await pageEvalAll(page, '#WorkSpaceBox #ctlActivityTable tr td', [], (tds) => {
+    return tds.map(td => ({
+      classList: td.getAttribute('class'),
+      innerText: td.innerText,
+    }));
+  });
 
   for (const element of tdsValues) {
     if (element.classList.includes('ExtendedActivityColumnDate')) {
@@ -122,24 +111,12 @@ async function extractCompletedTransactionsFromPage(page) {
 
 async function extractPendingTransactionsFromPage(page) {
   const txns = [];
-
-  let tdsValues;
-  try {
-    tdsValues = await page.$$eval('#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', (tds) => {
-      return tds.map(td => ({
-        classList: td.getAttribute('class'),
-        innerText: td.innerText,
-      }));
-    });
-  } catch (e) {
-    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
-      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
-      // they will release a new version.
-      tdsValues = [];
-    } else {
-      throw e;
-    }
-  }
+  const tdsValues = await pageEvalAll(page, '#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', [], (tds) => {
+    return tds.map(td => ({
+      classList: td.getAttribute('class'),
+      innerText: td.innerText,
+    }));
+  });
 
   for (const element of tdsValues) {
     if (element.classList.includes('Colume1Width')) {

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -67,12 +67,23 @@ function convertTransactions(txns) {
 async function extractCompletedTransactionsFromPage(page) {
   const txns = [];
 
-  const tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
-    return tds.map(td => ({
-      classList: td.getAttribute('class'),
-      innerText: td.innerText,
-    }));
-  });
+  let tdsValues;
+  try {
+    tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
+      return tds.map(td => ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+    });
+  } catch (e) {
+    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
+      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
+      // they will release a new version.
+      tdsValues = [];
+    } else {
+      throw e;
+    }
+  }
 
   for (const element of tdsValues) {
     if (element.classList.includes('ExtendedActivityColumnDate')) {
@@ -112,12 +123,23 @@ async function extractCompletedTransactionsFromPage(page) {
 async function extractPendingTransactionsFromPage(page) {
   const txns = [];
 
-  const tdsValues = await page.$$eval('#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', (tds) => {
-    return tds.map(td => ({
-      classList: td.getAttribute('class'),
-      innerText: td.innerText,
-    }));
-  });
+  let tdsValues;
+  try {
+    tdsValues = await page.$$eval('#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', (tds) => {
+      return tds.map(td => ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+    });
+  } catch (e) {
+    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
+      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
+      // they will release a new version.
+      tdsValues = [];
+    } else {
+      throw e;
+    }
+  }
 
   for (const element of tdsValues) {
     if (element.classList.includes('Colume1Width')) {

--- a/src/scrapers/otsar-hahayal.js
+++ b/src/scrapers/otsar-hahayal.js
@@ -70,12 +70,23 @@ function convertTransactions(txns) {
 }
 
 async function parseTransactionPage(page) {
-  const tdsValues = await page.$$eval('#dataTable077 tbody tr td', (tds) => {
-    return tds.map(td => ({
-      classList: td.getAttribute('class'),
-      innerText: td.innerText,
-    }));
-  });
+  let tdsValues;
+  try {
+    tdsValues = await page.$$eval('#dataTable077 tbody tr td', (tds) => {
+      return tds.map(td => ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+    });
+  } catch (e) {
+    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
+      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
+      // they will release a new version.
+      tdsValues = [];
+    } else {
+      throw e;
+    }
+  }
 
   const txns = [];
   for (const element of tdsValues) {

--- a/src/scrapers/otsar-hahayal.js
+++ b/src/scrapers/otsar-hahayal.js
@@ -1,7 +1,12 @@
 import moment from 'moment';
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
 import { waitForNavigation } from '../helpers/navigation';
-import { fillInput, clickButton, waitUntilElementFound } from '../helpers/elements-interactions';
+import {
+  fillInput,
+  clickButton,
+  waitUntilElementFound,
+  pageEvalAll,
+} from '../helpers/elements-interactions';
 import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE, SHEKEL_CURRENCY_SYMBOL } from '../constants';
 
 const BASE_URL = 'https://online.bankotsar.co.il';
@@ -70,23 +75,12 @@ function convertTransactions(txns) {
 }
 
 async function parseTransactionPage(page) {
-  let tdsValues;
-  try {
-    tdsValues = await page.$$eval('#dataTable077 tbody tr td', (tds) => {
-      return tds.map(td => ({
-        classList: td.getAttribute('class'),
-        innerText: td.innerText,
-      }));
-    });
-  } catch (e) {
-    if (e.message.indexOf('Error: failed to find elements matching selector') === 0) {
-      // temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until
-      // they will release a new version.
-      tdsValues = [];
-    } else {
-      throw e;
-    }
-  }
+  const tdsValues = await pageEvalAll(page, '#dataTable077 tbody tr td', [], (tds) => {
+    return tds.map(td => ({
+      classList: td.getAttribute('class'),
+      innerText: td.innerText,
+    }));
+  });
 
   const txns = [];
   for (const element of tdsValues) {


### PR DESCRIPTION
We are using puppeteer v1.5.0 as part of [israeli-bank-scrapers@0.6.0](https://github.com/eshaham/israeli-bank-scrapers/commit/1393ce5f04ce82f438087abad78c5075ce948c9a)

23 days ago they released version 1.5.0 where they changed the logic of `$$eval` and as a side effect it started failing when the selector is missing. this was not their original intention and they fix it for next version [here](https://github.com/GoogleChrome/puppeteer/pull/2740).

closes #133