### PR TITLE
playground: use latest api of csv2json v4

### DIFF
--- a/playground/scrape.js
+++ b/playground/scrape.js
@@ -14,7 +14,7 @@ async function exportAccountData(scraperId, account, saveLocation) {
       processedDate: moment(txn.processedDate).format('DD/MM/YYYY'),
     });
   });
-  const csv = json2csv({ data, withBOM: true });
+  const csv = json2csv.parse(data, { withBOM: true });
   await writeFile(`${saveLocation}/${SCRAPERS[scraperId].name} (${account.accountNumber}).csv`, csv);
 }
 


### PR DESCRIPTION
As part of this library [update packages](https://github.com/eshaham/israeli-bank-scrapers/commit/1393ce5f04ce82f438087abad78c5075ce948c9a) we upgraded json2csv v3.11.5 to v4.1.4. 

json2csv changed the api as part v4 (see [migration instructions](https://github.com/zemirco/json2csv#migrating-from-3x-to-4x)). 

This PR uses the new api to create a csv file in the playground.