### PR TITLE
Leumi Scraper - Support for no transactions available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,7 +948,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "babel-traverse": {
@@ -965,7 +965,7 @@
             "debug": "2.6.8",
             "globals": "9.18.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "babel-types": {
@@ -976,7 +976,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "to-fast-properties": "1.0.3"
           }
         },

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -67,12 +67,18 @@ function convertTransactions(txns) {
 async function extractCompletedTransactionsFromPage(page) {
   const txns = [];
 
-  const tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
-    return tds.map(td => ({
-      classList: td.getAttribute('class'),
-      innerText: td.innerText,
-    }));
-  });
+  let tdsValues = null;
+  try {
+    tdsValues = await page.$$eval('#WorkSpaceBox #ctlActivityTable tr td', (tds) => {
+      return tds.map(td => ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+    });
+  } catch (err) {
+    // it's possible that no completed transactions are available yet.
+    return txns;
+  }
 
   for (const element of tdsValues) {
     if (element.classList.includes('ExtendedActivityColumnDate')) {
@@ -112,12 +118,18 @@ async function extractCompletedTransactionsFromPage(page) {
 async function extractPendingTransactionsFromPage(page) {
   const txns = [];
 
-  const tdsValues = await page.$$eval('#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', (tds) => {
-    return tds.map(td => ({
-      classList: td.getAttribute('class'),
-      innerText: td.innerText,
-    }));
-  });
+  let tdsValues = null;
+  try {
+    tdsValues = await page.$$eval('#WorkSpaceBox #trTodayActivityNapaTableUpper tr td', (tds) => {
+      return tds.map(td => ({
+        classList: td.getAttribute('class'),
+        innerText: td.innerText,
+      }));
+    });
+  } catch (err) {
+    // it's possible that no pending transactions are available yet
+    return txns;
+  }
 
   for (const element of tdsValues) {
     if (element.classList.includes('Colume1Width')) {


### PR DESCRIPTION
I ran into an issue where I attempted to scrape the bank on the 1st day of the month.
In this case there were only completed transactions (salaries) and still no pending transactions.

The error I got in `israeli-ynab-updater` is the following:

```
scraping Bank Leumi
Bank Leumi: START_SCRAPING
Bank Leumi: INITIALIZING
Bank Leumi: LOGGING_IN
Bank Leumi: LOGIN_SUCCESS
Bank Leumi: TERMINATING
Bank Leumi: END_SCRAPING
success: false
error type: generic
error: Error: failed to find elements matching selector "#WorkSpaceBox #trTodayActivityNapaTableUpper tr td"
Error: Error: failed to find elements matching selector "#WorkSpaceBox #trTodayActivityNapaTableUpper tr td"
at /Users/ifeins/Development/web/israeli-ynab-updater/src/scrape/scrape-base.js:62:11
at Generator.next (<anonymous>)
at step (/Users/ifeins/Development/web/israeli-ynab-updater/src/scrape/scrape-base.js:47:191)
at /Users/ifeins/Development/web/israeli-ynab-updater/src/scrape/scrape-base.js:47:361
at <anonymous>
```

It's because the section for the pending transactions didn't appear in the page.
So I've added support that if no transactions are being fetched it simply returns an empty array.