### PR TITLE
visa-cal: catch error when failing to extract transactions

### DIFF
--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -204,6 +204,10 @@ async function getTransactionsForAllAccounts(authHeader, startMoment, options) {
             accounts.push(result);
           }
         }
+      } else {
+        const { Description, Message } = bankDebits.Response.Status;
+        const message = `${Description}. ${Message}`;
+        throw new Error(message);
       }
     }
     return {


### PR DESCRIPTION
Failing the scraping handling when failing to extract transaction, otherwise we ignore those errors and result with false status of "successful" scraping  0 transactions.

I'm trying to fix the problem that is causing this error but for now we should at least handle it correctly.

![image](https://user-images.githubusercontent.com/4751797/42326997-5dd94c26-8073-11e8-931d-162cb8e15380.png)
