### PR TITLE
Leumi Scraper - fix expand link id.

### DIFF
--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -160,7 +160,7 @@ async function fetchTransactionsForAccount(page, startDate) {
   await clickButton(page, 'input#btnDisplayDates');
   await waitForNavigation(page);
   await waitUntilElementFound(page, 'table#WorkSpaceBox table#ctlActivityTable');
-  await clickButton(page, 'a#lnkCtlExpandAll');
+  await clickButton(page, 'a#lnkCtlExpandAllInPage');
 
   const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
     return option.innerText;


### PR DESCRIPTION
The expand all transactions link id has changed which caused the scraper to break.
