### PR TITLE
Visa Cal - If bank account has no active cards, the scrape fails

### DIFF
--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -191,7 +191,7 @@ async function getTransactionsForAllAccounts(authHeader, startMoment, options) {
       const bank = banksResponse.BankAccounts[i];
       const bankDebits = await getBankDebits(authHeader, bank.AccountID);
       //Check that the bank has an active card to scrape
-      if (bank.Cards.some(_ => _.IsEffectiveInd)) {
+      if (bank.Cards.some(card => card.IsEffectiveInd)) {
         if (_.get(bankDebits, 'Response.Status.Succeeded')) {
           for (let j = 0; j < bank.Cards.length; j += 1) {
             const rawTxns = await getTxnsOfCard(authHeader, bank.Cards[j], bankDebits.Debits);

--- a/src/scrapers/visa-cal.js
+++ b/src/scrapers/visa-cal.js
@@ -190,6 +190,10 @@ async function getTransactionsForAllAccounts(authHeader, startMoment, options) {
     for (let i = 0; i < banksResponse.BankAccounts.length; i += 1) {
       const bank = banksResponse.BankAccounts[i];
       const bankDebits = await getBankDebits(authHeader, bank.AccountID);
+      if (bank.Cards.every(function (element){
+        return element.IsEffectiveInd === false;
+      }))
+          continue;
       if (_.get(bankDebits, 'Response.Status.Succeeded')) {
         for (let j = 0; j < bank.Cards.length; j += 1) {
           const rawTxns = await getTxnsOfCard(authHeader, bank.Cards[j], bankDebits.Debits);


### PR DESCRIPTION
The scrape fails if you have 2 or more bank accounts and all cards are inactive resulting in a generic error