### PR TITLE
bank-leumi: fix invalid url used to access accounts

### DIFF
--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -63,7 +63,7 @@ class BaseScraperWithBrowser extends BaseScraper {
     if (this.options.verbose) {
       env = Object.assign({ DEBUG: '*' }, process.env);
     }
-    
+
     if (typeof this.options.browser !== 'undefined' && this.options.browser !== null) {
       this.browser = this.options.browser;
     } else {

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -10,7 +10,7 @@ import {
 import { waitForNavigation } from '../helpers/navigation';
 import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE, TRANSACTION_STATUS } from '../constants';
 
-const BASE_URL = 'https://hb2.bankleumi.co.il/';
+const BASE_URL = 'https://hb2.bankleumi.co.il';
 const DATE_FORMAT = 'DD/MM/YY';
 
 function getTransactionsUrl() {


### PR DESCRIPTION
`leumi.js` was navigation to accounts page is broken due to changes in their site. Previously they accepted `//` as part of the url and now they don't.

Trying to run the scrape fails with message `Error: failed to find element matching selector "select#ddlTransactionPeriod"`

@eshaham I think you should consider deploying a new version as it is currently not possible to scrape bank leumi without this fix.
