### PR TITLE
srape bank leumi transactions in pages without expandable transactions

### DIFF
--- a/src/helpers/elements-interactions.js
+++ b/src/helpers/elements-interactions.js
@@ -29,6 +29,10 @@ async function pageEvalAll(page, selector, defaultResult, callback) {
   return result;
 }
 
+async function elementPresentOnPage(page, selector) {
+  return await page.$(selector) !== null;
+}
+
 async function dropdownSelect(page, selectSelector, value) {
   await page.select(selectSelector, value);
 }
@@ -39,4 +43,5 @@ export {
   clickButton,
   dropdownSelect,
   pageEvalAll,
+  elementPresentOnPage,
 };

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -6,6 +6,7 @@ import {
   clickButton,
   waitUntilElementFound,
   pageEvalAll,
+  elementPresentOnPage,
 } from '../helpers/elements-interactions';
 import { waitForNavigation } from '../helpers/navigation';
 import { SHEKEL_CURRENCY, NORMAL_TXN_TYPE, TRANSACTION_STATUS } from '../constants';
@@ -160,7 +161,12 @@ async function fetchTransactionsForAccount(page, startDate) {
   await clickButton(page, 'input#btnDisplayDates');
   await waitForNavigation(page);
   await waitUntilElementFound(page, 'table#WorkSpaceBox table#ctlActivityTable');
-  await clickButton(page, 'a#lnkCtlExpandAllInPage');
+
+  const hasExpandAllButton = await elementPresentOnPage(page, 'a#lnkCtlExpandAllInPage');
+
+  if (hasExpandAllButton) {
+    await clickButton(page, 'a#lnkCtlExpandAllInPage');
+  }
 
   const selectedSnifAccount = await page.$eval('#ddlAccounts_m_ddl option[selected="selected"]', (option) => {
     return option.innerText;


### PR DESCRIPTION
Check if expand button exists before trying to click on it, otherwise the scraper will fail.

![image](https://user-images.githubusercontent.com/4751797/52324445-01281180-29ea-11e9-896f-2a26ff32c3fd.png)
