### PR TITLE
Fix leumi card stuck in popup before login

### DIFF
--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -119,6 +119,9 @@ class BaseScraperWithBrowser extends BaseScraper {
     }
 
     await this.fillInputs(loginOptions.fields);
+    if (loginOptions.preAction) {
+      await loginOptions.preAction();
+    }
     await clickButton(this.page, loginOptions.submitButtonSelector);
     this.emitProgress(SCRAPE_PROGRESS_TYPES.LOGGING_IN);
 

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -118,10 +118,10 @@ class BaseScraperWithBrowser extends BaseScraper {
       await waitUntilElementFound(this.page, loginOptions.submitButtonSelector);
     }
 
-    await this.fillInputs(loginOptions.fields);
     if (loginOptions.preAction) {
       await loginOptions.preAction();
     }
+    await this.fillInputs(loginOptions.fields);
     await clickButton(this.page, loginOptions.submitButtonSelector);
     this.emitProgress(SCRAPE_PROGRESS_TYPES.LOGGING_IN);
 

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 import { BaseScraperWithBrowser, LOGIN_RESULT } from './base-scraper-with-browser';
 import { waitForNavigationAndDomLoad, waitForRedirect } from '../helpers/navigation';
-import { waitUntilElementFound } from '../helpers/elements-interactions';
+import { waitUntilElementFound, elementPresentOnPage, clickButton } from '../helpers/elements-interactions';
 import {
   NORMAL_TXN_TYPE,
   INSTALLMENTS_TXN_TYPE,
@@ -329,6 +329,11 @@ class LeumiCardScraper extends BaseScraperWithBrowser {
       loginUrl: `${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`,
       fields: createLoginFields(inputGroupName, credentials),
       submitButtonSelector: `#${inputGroupName}_btnLogin`,
+      preAction: async () => {
+        if (await elementPresentOnPage(this.page, '#closePopup')) {
+          await clickButton(this.page, '#closePopup');
+        }
+      },
       postAction: async () => redirectOrDialog(this.page),
       possibleResults: getPossibleLoginResults(),
     };


### PR DESCRIPTION
This PR fixes a bug that Leumi card scraper currently fails to login because they added a popup that you need to close before logging in.

Changes:
- Added support for a generic pre login hook in base-scraper-with-browser
- Made the leumi card scraper run a pre login hook that closes the popup that prevents login.