### PR TITLE
Fix leumi card rebranding

### DIFF
--- a/src/helpers/navigation.js
+++ b/src/helpers/navigation.js
@@ -21,12 +21,13 @@ export async function getCurrentUrl(page, clientSide = false) {
   return page.url();
 }
 
-export async function waitForRedirect(page, timeout = 20000, clientSide = false) {
+export async function waitForRedirect(page, timeout = 20000, clientSide = false, ignoreList = []) {
   const initial = await getCurrentUrl(page, clientSide);
+
   try {
     await waitUntil(async () => {
       const current = await getCurrentUrl(page, clientSide);
-      return current !== initial;
+      return current !== initial && ignoreList.indexOf(current) === -1;
     }, `waiting for redirect from ${initial}`, timeout, 1000);
   } catch (e) {
     if (e && e.timeout) {

--- a/src/helpers/navigation.js
+++ b/src/helpers/navigation.js
@@ -27,7 +27,7 @@ export async function waitForRedirect(page, timeout = 20000, clientSide = false,
   try {
     await waitUntil(async () => {
       const current = await getCurrentUrl(page, clientSide);
-      return current !== initial && ignoreList.indexOf(current) === -1;
+      return current !== initial && !ignoreList.includes(current);
     }, `waiting for redirect from ${initial}`, timeout, 1000);
   } catch (e) {
     if (e && e.timeout) {

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -19,7 +19,7 @@ function getKeyByValue(object, value) {
         return item.test(value);
       }
 
-      return value === item;
+      return value.toLowerCase() === item.toLowerCase();
     });
 
     return !!result;

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -30,7 +30,7 @@ const CREDIT_TYPE_NAME = 'קרדיט';
 
 function redirectOrDialog(page) {
   return Promise.race([
-    waitForRedirect(page),
+    waitForRedirect(page, 20000, false, [BASE_WELCOME_URL, `${BASE_WELCOME_URL}/`]),
     waitUntilElementFound(page, '#popupWrongDetails', true),
   ]);
 }

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -14,7 +14,8 @@ import {
 import getAllMonthMoments from '../helpers/dates';
 import { fixInstallments, sortTransactionsByDate, filterOldTransactions } from '../helpers/transactions';
 
-const BASE_URL = 'https://online.leumi-card.co.il';
+const BASE_ACTIONS_URL = 'https://online.max.co.il';
+const BASE_WELCOME_URL = 'https://www.max.co.il';
 const DATE_FORMAT = 'DD/MM/YYYY';
 const NORMAL_TYPE_NAME = 'רגילה';
 const ATM_TYPE_NAME = 'חיוב עסקות מיידי';
@@ -44,7 +45,7 @@ function getTransactionsUrl(monthMoment) {
     monthCharge = `${year}${monthStr}`;
     actionType = 2;
   }
-  return buildUrl(BASE_URL, {
+  return buildUrl(BASE_ACTIONS_URL, {
     path: 'Registred/Transactions/ChargesDeals.aspx',
     queryParams: {
       ActionType: actionType,
@@ -309,9 +310,9 @@ async function fetchTransactions(browser, options, navigateToFunc) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/Registred/HomePage.aspx`];
-  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/Anonymous/Login/PasswordExpired.aspx`];
-  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`];
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_WELCOME_URL}/homepage/personal`];
+  urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_ACTIONS_URL}/Anonymous/Login/PasswordExpired.aspx`];
+  urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_ACTIONS_URL}/Anonymous/Login/CardHoldersLogin.aspx`];
   return urls;
 }
 
@@ -326,7 +327,7 @@ class LeumiCardScraper extends BaseScraperWithBrowser {
   getLoginOptions(credentials) {
     const inputGroupName = 'PlaceHolderMain_CardHoldersLogin1';
     return {
-      loginUrl: `${BASE_URL}/Anonymous/Login/CardHoldersLogin.aspx`,
+      loginUrl: `${BASE_ACTIONS_URL}/Anonymous/Login/CardholdersLogin.aspx`,
       fields: createLoginFields(inputGroupName, credentials),
       submitButtonSelector: `#${inputGroupName}_btnLogin`,
       preAction: async () => {

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -287,17 +287,18 @@ async function fetchTransactions(browser, options, navigateToFunc) {
 
   const allTasks = [];
   for (let i = 0; i < allMonths.length; i += 1) {
-    const task = fetchTransactionsForMonth(browser, navigateToFunc, allMonths[i]);
+    const task = () => fetchTransactionsForMonth(browser, navigateToFunc, allMonths[i]);
     allTasks.push(task);
   }
 
-  const task = fetchTransactionsForMonth(browser, navigateToFunc);
+  const task = () => fetchTransactionsForMonth(browser, navigateToFunc);
   allTasks.push(task);
 
-  const allTasksResults = await Promise.all(allTasks);
-  const allResults = allTasksResults.reduce((obj, result) => {
-    return addResult(obj, result);
-  }, {});
+  let allResults = {};
+  for (const task of allTasks) {
+    const result = await task();
+    allResults = addResult(allResults, result);
+  }
 
   Object.keys(allResults).forEach((accountNumber) => {
     let txns = allResults[accountNumber];

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -285,20 +285,14 @@ async function fetchTransactions(browser, options, navigateToFunc) {
   const startMoment = moment.max(defaultStartMoment, moment(startDate));
   const allMonths = getAllMonthMoments(startMoment, false);
 
-  const allTasks = [];
-  for (let i = 0; i < allMonths.length; i += 1) {
-    const task = () => fetchTransactionsForMonth(browser, navigateToFunc, allMonths[i]);
-    allTasks.push(task);
-  }
-
-  const task = () => fetchTransactionsForMonth(browser, navigateToFunc);
-  allTasks.push(task);
-
   let allResults = {};
-  for (const task of allTasks) {
-    const result = await task();
+  for (let i = 0; i < allMonths.length; i += 1) {
+    const result = await fetchTransactionsForMonth(browser, navigateToFunc, allMonths[i]);
     allResults = addResult(allResults, result);
   }
+
+  const currentMonthResult = await fetchTransactionsForMonth(browser, navigateToFunc);
+  allResults = addResult(allResults, currentMonthResult);
 
   Object.keys(allResults).forEach((accountNumber) => {
     let txns = allResults[accountNumber];


### PR DESCRIPTION
# Motivation
1. Fix Leumi Card scraper that was broken by the new website (the max rebranding)
2. Fix recognition of invalid user/password flow
3. Fix unexpected error that happens when scraping more then multiple months. It doesn't happen all the times but still quite frequently

# Infrastructure adjustments

## Navigation > waitForRedirect
To support the new leumi card login flow, `waitForRedirect` method was adjusted to optionally ignore redirect if needed

##  Compare login target with case insensitive
The leumi card site might redirect to same page with different case sensitive when typing invalid password

fixes #179 