### PR TITLE
Fixed leumi card truncated transaction descriptions

### DIFF
--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -164,9 +164,8 @@ async function getTransactionsForSection(page, cardIndex, sectionIndex) {
   const txnsRows = await cardSections[sectionIndex].$$('.jobs_regular');
   const expandedBusinessesNamesHeaders = await cardSections[sectionIndex].$$('.openedJob .bisName');
   let expandedBusinessesNames = await Promise.all(expandedBusinessesNamesHeaders.map(
-    header => page.evaluate(y => y.innerText, header),
-  ),
-  expandedBusinessesNamesHeaders);
+    header => page.evaluate(x => x.innerText, header),
+  ), expandedBusinessesNamesHeaders);
 
   // Leumicard keeps hidden open transactions without any content, filter them out
   expandedBusinessesNames = expandedBusinessesNames.filter(x => !!x);
@@ -195,7 +194,6 @@ async function getTransactionsForSection(page, cardIndex, sectionIndex) {
       return td.innerText;
     }, txnColumns[6]);
 
-    // take the description from the hidden expanded info-card, as the one in the table is truncated
     const description = expandedBusinessesNames[txnIndex].replace(/\s+/g, ' ');
 
     const comments = await page.evaluate((td) => {


### PR DESCRIPTION
When scraping leumi card/MAX forex transaction, the description gets truncated.
This change brings the full description from a hidden box that is usually displayed when the transaction is clicked.

![Screen Shot 2019-05-18 at 21 03 06](https://user-images.githubusercontent.com/1201448/57976013-06c8c680-79df-11e9-8c7c-15a93dd1ba77.png)
