### PR TITLE
Attempt to Fix Visa Cal scraper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2446,7 +2446,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2642,8 +2641,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2733,8 +2731,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -33,6 +33,8 @@ export async function fetchPost(url, data, extraHeaders) {
     body: JSON.stringify(data),
   };
   const result = await nodeFetch(url, request);
+  const resultText = await result.text();
+  console.log(`Auth result: ${resultText}`);
   return result.json();
 }
 


### PR DESCRIPTION
I've applied the changes suggested by @sagiba in https://github.com/eshaham/israeli-bank-scrapers/issues/200 but I'm still unable to get the scraper to work.

It fails with the following output:

```
➜  israeli-bank-scrapers git:(fix_visa_cal_scraper) ✗ npm start

> israeli-bank-scrapers@0.6.7 start /Users/ifeins/Development/israeli-bank-scrapers
> node -r babel-register playground/scrape.js

Visa Cal: START_SCRAPING
Visa Cal: INITIALIZING
Visa Cal: LOGGING_IN
Auth result: "שם המשתמש או הסיסמה שהוזנו שגויים"
Visa Cal: TERMINATING
Visa Cal: END_SCRAPING
success: false
error type: generic
error: body used already for: https://connect.cal-online.co.il/api/authentication/login
```

@sagiba Can you let me know if I've missed anything?