### PR TITLE
Leumi Card failed because next month is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ lib/
 
 # IDEs
 .idea
+.vscode

--- a/src/scrapers/leumi-card.js
+++ b/src/scrapers/leumi-card.js
@@ -115,8 +115,10 @@ async function fetchTransactionsForMonth(page, monthMoment) {
   const url = getTransactionsUrl(monthMoment);
 
   const data = await fetchGetWithinPage(page, url);
-
   const transactionsByAccount = {};
+
+  if (!data.result) return transactionsByAccount;
+
   data.result.transactions.forEach((transaction) => {
     if (!transactionsByAccount[transaction.shortCardNumber]) {
       transactionsByAccount[transaction.shortCardNumber] = [];


### PR DESCRIPTION
When I scrape the Leumi Card, the next month request returns with `data.result` is `null`.

The test failed before the repair and is now passing.