### PR TITLE
Add GithubAction for CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,25 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, lint, and test
+      run: |
+        npm install
+        npm run lint
+        npm run test:ci

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "test": "BABEL_ENV=test jest",
+    "test:ci" : "cp tests/.tests-config.tpl.js tests/.tests-config.js && npm run test",
     "lint": "eslint src",
     "prepublishOnly": "npm run clean && babel src --out-dir lib"
   },


### PR DESCRIPTION
Configurations for using [*Github Actions*](https://github.com/features/actions) as CI service.

The *Github Actions* will run the script `test:ci` in dockers according to the `matrix`.

The `matrix` defines both **OS** and **Node version**, so for each OS and version combination, there will be a **docker container** to run the `test:ci`.

Of course, it will only run the tests that don't require login information. It's not perfect, but it can be a start.