### PR TITLE
add prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Make prerelease to npm
-        uses: epeli/npm-release@v1
+        uses: epeli/npm-release@bc78fc8
         with:
           type: prerelease
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Make prerelease to npm
+        uses: epeli/npm-release@v1
+        with:
+          type: prerelease
+          token: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you are a developer and want to access the `next` version, install the librar
 npm install israeli-bank-scrapers@next --save
 ```  
 
-> Keep in mind that although this version should be stable as it passed our code review, it was deployed automatically using github action workflow without the usual tests we run manually done before we deploy the official version.  
+> Keep in mind that although this `next` version should be stable as it passed our code review, it was deployed automatically using github action workflow without the usual tests we run manually before we deploy the official version.  
 
 # `Israeli-bank-scrapers-core` library
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The return value is a list of scraper metadata:
 # Getting deployed version of latest changes in master
 This library is currently deployed to NPM manually and not as part of automatic process. You should expect situations when code was pushed to master and wasn't deployed to NPM yet.
 
-If you are a developer and want to access the `next` version, install the library with `next tag as shown below:
+If you are a developer and want to access the `next` version, install the library with `next` tag as shown below:
 ```sh
 npm install israeli-bank-scrapers@next --save
 ```  

--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ The return value is a list of scraper metadata:
 }
 ```
 
+# Getting deployed version of latest changes in master
+This library is currently deployed to NPM manually and not as part of automatic process. You should expect situations when code was pushed to master and wasn't deployed to NPM yet.
+
+If you are a developer and want to access the `next` version, install the library with `next tag as shown below:
+```sh
+npm install israeli-bank-scrapers@next --save
+```  
+
+> Keep in mind that although this version should be stable as it passed our code review, it was deployed automatically using github action workflow without the usual tests we run manually done before we deploy the official version.  
+
 # `Israeli-bank-scrapers-core` library
 
 > TL;DR this is the same library as the default library. The only difference is that it is using `puppeteer-core` instead of `puppeteer` which is useful if you are using frameworks like Electron to pack your application. 


### PR DESCRIPTION
I admit that @baruchiro infected me with the github actions thing. I found a workflow that can be used to deploy a prerelease version to npm in a smart way and label it with `next` tag. 

@eshaham This might be really handy in our case. Having an automatic process that deploys a temporary `next` version will allow developers to use merged PRs changes immediately instead of waiting for an official release

I marked this PR as draft to consult with you both @eshaham and @baruchiro about the implementation. this workflow is using `epeli/npm-release` action. although it is very popular using others actions, I'm not sure how comfortable I feel to pass the NPM secret (of Elad) to that action. @baruchiro how about coping that action into our own project and using a local copy instead? its' license is MIT so I'm sure it is legit and I think we will feel more secure that way. wdyt? are you using somewhere local actions?
