### PR TITLE
build library before prerelease and support prerelease or core version

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,7 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Make prerelease to npm
+      - name: prepare default version
+        run: npm run prepare:default
+      - name: Make prerelease of default version to npm
+        uses: epeli/npm-release@bc78fc8
+        with:
+          type: prerelease
+          token: ${{ secrets.NPM_TOKEN }}
+      - name: prepare core version
+        run: |
+          npm run reset
+          npm run prepare:core
+      - name: Make prerelease of core version to npm
         uses: epeli/npm-release@bc78fc8
         with:
           type: prerelease


### PR DESCRIPTION
@eshaham it is fun playing with github actions :) I was curious to see the results of the automatic process and this is what we got when installing the `next` version:
![image](https://user-images.githubusercontent.com/4751797/66255052-c8faed80-e787-11e9-9369-d1f40be3ee4f.png)

obviously since I didn't run the `build` scripts as part of the workflow, the prerelease is missing `libs` folder :)

I fixed the workflow and also added support for prerelease of `core` version. As I don't have playground to work with let's try this one out and see if it result with valid releases

relates to #273 