### PR TITLE
Leumi login case-insensitive

### DIFF
--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -45,6 +45,7 @@ function handleLoginResult(scraper, loginResult) {
       return {
         success: false,
         errorType: loginResult,
+        errorMessage: `Login failed with ${loginResult} error`,
       };
     case LOGIN_RESULT.CHANGE_PASSWORD:
       scraper.emitProgress(SCRAPE_PROGRESS_TYPES.CHANGE_PASSWORD);

--- a/src/scrapers/leumi.js
+++ b/src/scrapers/leumi.js
@@ -22,7 +22,7 @@ function getTransactionsUrl() {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = [/ebanking\/SO\/SPA.aspx/];
+  urls[LOGIN_RESULT.SUCCESS] = [/ebanking\/SO\/SPA.aspx/i];
   urls[LOGIN_RESULT.INVALID_PASSWORD] = [/InternalSite\/CustomUpdate\/leumi\/LoginPage.ASP/];
   // urls[LOGIN_RESULT.CHANGE_PASSWORD] = ``; // TODO should wait until my password expires
   return urls;


### PR DESCRIPTION
close #296 

- [x] The login result is `eBanking` now (with upper B).
- [x] The login result gets `UNKNOWN_ERROR`, and the login know that is a login result, but in the end, you see the login succeeds, but you get the `UNKNOWN_ERROR` and you don't know it is a login result.