### PR TITLE
Fix success url for discount bank's new ui #322

### DIFF
--- a/src/scrapers/discount.js
+++ b/src/scrapers/discount.js
@@ -79,7 +79,7 @@ async function navigateOrErrorLabel(page) {
 
 function getPossibleLoginResults() {
   const urls = {};
-  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`];
+  urls[LOGIN_RESULT.SUCCESS] = [`${BASE_URL}/apollo/core/templates/RETAIL/masterPage.html#/MY_ACCOUNT_HOMEPAGE`];
   urls[LOGIN_RESULT.INVALID_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LOGIN_RESULT.CHANGE_PASSWORD] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;


### PR DESCRIPTION
Discount updated their ui and now after login the url is: 

`https://start.telebank.co.il/apollo/core/templates/RETAIL/masterPage.html#/MY_ACCOUNT_HOMEPAGE` 

as opposed to:

 
`https://start.telebank.co.il/apollo/core/templates/default/masterPage.html#/MY_ACCOUNT_HOMEPAGE`