### PR TITLE
Change Isracard default start date to earlier

### DIFF
--- a/src/scrapers/base-isracard-amex.js
+++ b/src/scrapers/base-isracard-amex.js
@@ -268,7 +268,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser {
   }
 
   async fetchData() {
-    const defaultStartMoment = moment().subtract(1, 'years');
+    const defaultStartMoment = moment().subtract(4, 'years');
     const startDate = this.options.startDate || defaultStartMoment.toDate();
     const startMoment = moment.max(defaultStartMoment, moment(startDate));
 


### PR DESCRIPTION
Isracard is capable of returning older history then just 1 year.

On my account I was able to go back 4 years but maybe for others it might be even longer.

Not sure if it's a known thing and you just wanted to send back 1 year as default?
For me it made me think that the scraper can't bring earlier data but I decide to try it anyway.