### PR TITLE
Dont stale dependencies PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - dependencies
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Currently, all PRs are marked as stale after a period of inactivity - this PR excludes PRs that update dependencies created by dependabot.