### PR TITLE
support custom args provided by user to puppeteer lunch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,8 @@ copy and adjust the json below with relevant credentials and assign it to enviro
      "startDate": "2019-06-01",
      "combineInstallments": false,
      "showBrowser": true,
-     "verbose": false
+     "verbose": false,
+     "args": []
    },
    "credentials": {
      "leumi": { "username": "demouser", "password": "demopassword" }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The definition of the `options` object is as follows:
   verbose: boolean, // include more debug info about in the output
   browser : Browser, // optional option from init puppeteer browser instance outside the libary scope. you can get browser diretly from puppeteer via `puppeteer.launch()` command.
   executablePath: string, // optional. provide a patch to local chromium to be used by puppeteer. Relevant when using `israeli-bank-scrapers-core` library
-  args: {} // optional.  additional arguments to pass to the browser instance. The list of flags can be found below in (*)
+  args: {}, // optional.  additional arguments to pass to the browser instance. The list of flags can be found below in (*),
+  prepareBrowser: async (browser) => {}, // optional. adjust the browser instance before it is being used. 
+  preparePage: async (page) => {}, // optional. adjust the page instance before it is being used.
 }
 ```
 (*) links of flags that can be used with `args` options can be found [here](https://peter.sh/experiments/chromium-command-line-switches/), and [here](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options) is the list of Firefox flags.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,12 @@ The definition of the `options` object is as follows:
   showBrowser: boolean, // shows the browser while scraping, good for debugging (default false)
   verbose: boolean, // include more debug info about in the output
   browser : Browser, // optional option from init puppeteer browser instance outside the libary scope. you can get browser diretly from puppeteer via `puppeteer.launch()` command.
-  executablePath: string // optional. provide a patch to local chromium to be used by puppeteer. Relevant when using `israeli-bank-scrapers-core` library 
+  executablePath: string, // optional. provide a patch to local chromium to be used by puppeteer. Relevant when using `israeli-bank-scrapers-core` library
+  args: {} // optional.  additional arguments to pass to the browser instance. The list of flags can be found below in (*)
 }
 ```
+(*) links of flags that can be used with `args` options can be found [here](https://peter.sh/experiments/chromium-command-line-switches/), and [here](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options) is the list of Firefox flags.
+
 The structure of the result object is as follows:
 ```node
 {

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -78,10 +78,12 @@ class BaseScraperWithBrowser extends BaseScraper {
       this.browser = this.options.browser;
     } else {
       const executablePath = this.options.executablePath || undefined;
+      const args = this.options.args || [];
       this.browser = await puppeteer.launch({
         env,
         headless: !this.options.showBrowser,
         executablePath,
+        args,
       });
     }
 

--- a/src/scrapers/base-scraper-with-browser.js
+++ b/src/scrapers/base-scraper-with-browser.js
@@ -87,12 +87,21 @@ class BaseScraperWithBrowser extends BaseScraper {
       });
     }
 
+    if (this.options.prepareBrowser) {
+      await this.options.prepareBrowser(this.browser);
+    }
+
     const pages = await this.browser.pages();
     if (pages.length) {
       [this.page] = pages;
     } else {
       this.page = await this.browser.newPage();
     }
+
+    if (this.options.preparePage) {
+      await this.options.preparePage(this.page);
+    }
+
     await this.page.setViewport({
       width: VIEWPORT_WIDTH,
       height: VIEWPORT_HEIGHT,

--- a/src/scrapers/base-scraper-with-browser.test.js
+++ b/src/scrapers/base-scraper-with-browser.test.js
@@ -1,0 +1,56 @@
+import {
+  extendAsyncTimeout, getTestsConfig,
+} from '../../tests/tests-utils';
+import { BaseScraperWithBrowser } from './base-scraper-with-browser';
+
+const testsConfig = getTestsConfig();
+
+function isNoSandbox(browser) {
+  // eslint-disable-next-line no-underscore-dangle
+  const args = browser._process.spawnargs;
+  return args.includes('--no-sandbox');
+}
+
+describe('Base scraper with browser', () => {
+  beforeAll(() => {
+    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+  });
+
+  test('should pass custom args to scraper if provided', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: 'test',
+      showBrowser: false,
+      args: [],
+    };
+
+    // avoid false-positive result by confirming that --no-sandbox is not a default flag provided by puppeteer
+    let baseScraperWithBrowser = new BaseScraperWithBrowser(options);
+    try {
+      await baseScraperWithBrowser.initialize();
+      expect(baseScraperWithBrowser.browser).toBeDefined();
+      expect(isNoSandbox(baseScraperWithBrowser.browser)).toBe(false);
+      await baseScraperWithBrowser.terminate();
+    } catch (e) {
+      await baseScraperWithBrowser.terminate();
+      throw e;
+    }
+
+    // set --no-sandbox flag and expect it to be passed by puppeteer.lunch to the new created browser instance
+    options.args = [
+      '--no-sandbox',
+      '--disable-gpu',
+      '--window-size=1920x1080',
+    ];
+    baseScraperWithBrowser = new BaseScraperWithBrowser(options);
+    try {
+      await baseScraperWithBrowser.initialize();
+      expect(baseScraperWithBrowser.browser).toBeDefined();
+      expect(isNoSandbox(baseScraperWithBrowser.browser)).toBe(true);
+      await baseScraperWithBrowser.terminate();
+    } catch (e) {
+      await baseScraperWithBrowser.terminate();
+      throw e;
+    }
+  });
+});

--- a/tests/.tests-config.tpl.js
+++ b/tests/.tests-config.tpl.js
@@ -7,6 +7,7 @@ export default {
     combineInstallments: false,
     showBrowser: true,
     verbose: false,
+    args: []
   },
   credentials: { // commented companies will be skipped automatically, uncomment those you wish to test
     // hapoalim: { userCode: '', password: '' },


### PR DESCRIPTION
# Overview
Add optional args option to be provided as-is to the `puppeteer.lunch` command. Includes unit-tests.

#closes #419