### PR TITLE
filter out irrelevant max transaction records

### DIFF
--- a/src/scrapers/max.js
+++ b/src/scrapers/max.js
@@ -125,14 +125,17 @@ async function fetchTransactionsForMonth(page, monthMoment) {
 
   if (!data.result) return transactionsByAccount;
 
-  data.result.transactions.forEach((transaction) => {
-    if (!transactionsByAccount[transaction.shortCardNumber]) {
-      transactionsByAccount[transaction.shortCardNumber] = [];
-    }
+  data.result.transactions
+    // Filter out non-transactions without a plan type, e.g. summary rows
+    .filter((transaction) => !!transaction.planName)
+    .forEach((transaction) => {
+      if (!transactionsByAccount[transaction.shortCardNumber]) {
+        transactionsByAccount[transaction.shortCardNumber] = [];
+      }
 
-    const mappedTransaction = mapTransaction(transaction);
-    transactionsByAccount[transaction.shortCardNumber].push(mappedTransaction);
-  });
+      const mappedTransaction = mapTransaction(transaction);
+      transactionsByAccount[transaction.shortCardNumber].push(mappedTransaction);
+    });
 
   return transactionsByAccount;
 }


### PR DESCRIPTION
Apparently max returns summary titles masqueraded as transaction records, leading to a "Unknown transaction type" error.
These titles are used when you make mini-payments throughout the month, like for USD transactions.

 
![Screen Shot 2020-06-26 at 14 05 27](https://user-images.githubusercontent.com/1201448/85851399-46074080-b7b7-11ea-81b4-a2a4dd9071fd.png)
