### PR TITLE
Make prepareBrowser and preparePage optional in ScraperOptions

### DIFF
--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -81,14 +81,14 @@ export interface ScaperOptions {
    *
    * @param browser
    */
-  prepareBrowser: (browser: Browser) => Promise<void>;
+  prepareBrowser?: (browser: Browser) => Promise<void>;
 
   /**
    * adjust the page instance before it is being used.
    *
    * @param page
    */
-  preparePage: (page: Page) => Promise<void>;
+  preparePage?: (page: Page) => Promise<void>;
 }
 
 export enum ScaperProgressTypes {


### PR DESCRIPTION
Currently the interface of `ScaperOptions` has `prepareBrowser` and `prepagePage` as required options.

These don't seem like options that should be required because not all use cases need these. And the code itself checks if they exist or not so this will not break the existing code.