### PR TITLE
Fix import puppeteer in core library

### DIFF
--- a/src/helpers/elements-interactions.ts
+++ b/src/helpers/elements-interactions.ts
@@ -5,6 +5,10 @@ async function waitUntilElementFound(page: Page, elementSelector: string,
   await page.waitForSelector(elementSelector, { visible: onlyVisible, timeout });
 }
 
+async function waitUntilElementDisappear(page: Page, elementSelector: string, timeout = 30000) {
+  await page.waitForSelector(elementSelector, { hidden: true, timeout });
+}
+
 async function fillInput(page: Page, inputSelector: string, inputValue: string): Promise<void> {
   await page.$eval(inputSelector, (input: Element) => {
     const inputElement = input;
@@ -67,6 +71,7 @@ async function dropdownElements(page: Page, selector: string) {
 
 export {
   waitUntilElementFound,
+  waitUntilElementDisappear,
   fillInput,
   clickButton,
   clickLink,

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -3,13 +3,13 @@ import { Page, Request } from 'puppeteer';
 import {
   SHEKEL_CURRENCY,
 } from '../constants';
-import { BaseScraperWithBrowser, LoginResults, PossibleLoginResults } from './base-scraper-with-browser';
+import { pageEvalAll, waitUntilElementDisappear, waitUntilElementFound } from '../helpers/elements-interactions';
 import { fetchPostWithinPage } from '../helpers/fetch';
-import { pageEvalAll, waitUntilElementFound } from '../helpers/elements-interactions';
 import {
   Transaction, TransactionStatuses, TransactionTypes,
 } from '../transactions';
-import { ScraperErrorTypes, ScraperCredentials } from './base-scraper';
+import { ScraperCredentials, ScraperErrorTypes } from './base-scraper';
+import { BaseScraperWithBrowser, LoginResults, PossibleLoginResults } from './base-scraper-with-browser';
 
 interface ScrapedTransaction {
   RecTypeSpecified: boolean;
@@ -142,7 +142,7 @@ class MizrahiScraper extends BaseScraperWithBrowser {
       loginUrl: LOGIN_URL,
       fields: createLoginFields(credentials),
       submitButtonSelector,
-      checkReadiness: async () => this.page.waitForSelector(loginSpinnerSelector, { hidden: true }),
+      checkReadiness: async () => waitUntilElementDisappear(this.page, loginSpinnerSelector),
       postAction: async () => postLogin(this.page),
       possibleResults: getPossibleLoginResults(this.page),
     };


### PR DESCRIPTION
I don't know how the `prepare:core` is actually work, but when I'm trying to use `v1.0.0`, I'm getting an error and the problem is in `mizrahi.d.ts` with the line `checkReadiness: () => Promise<import("puppeteer").ElementHandle<Element>>;`.

It shouldn't use `puppeteer` in the `core` library.

So I changed this function to work as the other `elementInteractions` and to return `Promise<void>` so no `puppeteer` in the return type.