### PR TITLE
add POSTPONED_TRANSACTION_INSTALLMENTS to max

### DIFF
--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -41,6 +41,7 @@ const TWO_MONTHS_POSTPONED_TYPE_NAME = 'דחוי חודשיים';
 const MONTHLY_CHARGE_PLUS_INTEREST_TYPE_NAME = 'חודשי + ריבית';
 const CREDIT_TYPE_NAME = 'קרדיט';
 const ACCUMULATING_BASKET = 'סל מצטבר';
+const POSTPONED_TRANSACTION_INSTALLMENTS = 'פריסת העסקה הדחויה';
 
 const INVALID_DETAILS_SELECTOR = '#popupWrongDetails';
 const LOGIN_ERROR_SELECTOR = '#popupCardHoldersLoginError';
@@ -85,6 +86,7 @@ function getTransactionType(txnTypeStr: string) {
     case ACCUMULATING_BASKET:
     case INTERNET_SHOPPING_TYPE_NAME:
     case MONTHLY_CHARGE_PLUS_INTEREST_TYPE_NAME:
+    case POSTPONED_TRANSACTION_INSTALLMENTS:
       return TransactionTypes.Normal;
     case INSTALLMENTS_TYPE_NAME:
     case CREDIT_TYPE_NAME:


### PR DESCRIPTION
echo the change of #530 without running prettier on the max scraper and verify that eslint passes.

@gczobel your IDE is probably running Prettier with different set of rules which breaks our eslint tests and also present more changes then needed. see https://github.com/eshaham/israeli-bank-scrapers/pull/530/files

for example: 
```
/Users/eransakal/dev/github/eshaham/israeli-bank-scrapers/src/scrapers/max.ts
  44:44  error  Strings must use singlequote  @typescript-eslint/quotes
```

Please let me know if this PR work and if so we will merge this one instead.

closes #529 #530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eshaham/israeli-bank-scrapers/531)
<!-- Reviewable:end -->
