### PR TITLE
fix: add endDate to base-scrapper

### DIFF
--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -1,14 +1,11 @@
 import moment, { Moment } from 'moment';
 
-export default function getAllMonthMoments(startMoment: Moment | string, includeNext: boolean) {
+export default function getAllMonthMoments(startMoment: Moment | string, endMoment: Moment | string) {
   let monthMoment = moment(startMoment).startOf('month');
 
   const allMonths: Moment[] = [];
-  let lastMonth = moment().startOf('month');
-  if (includeNext) {
-    lastMonth = lastMonth.add(1, 'month');
-  }
-  while (monthMoment.isSameOrBefore(lastMonth)) {
+
+  while (monthMoment.isSameOrBefore(endMoment)) {
     allMonths.push(monthMoment);
     monthMoment = moment(monthMoment).add(1, 'month');
   }

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -232,8 +232,8 @@ async function fetchTransactions(page: Page, options: ExtendedScraperOptions, st
   return {};
 }
 
-async function fetchAllTransactions(page: Page, options: ExtendedScraperOptions, startMoment: Moment) {
-  const allMonths = getAllMonthMoments(startMoment, true);
+async function fetchAllTransactions(page: Page, options: ExtendedScraperOptions, startMoment: Moment, endMoment: Moment) {
+  const allMonths = getAllMonthMoments(startMoment, endMoment);
   const results: ScrapedAccountsWithIndex[] = await Promise.all(allMonths.map(async (monthMoment) => {
     return fetchTransactions(page, options, startMoment, monthMoment);
   }));
@@ -351,14 +351,17 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser {
 
   async fetchData() {
     const defaultStartMoment = moment().subtract(1, 'years');
+    const defaultEndMoment = moment().subtract(1, 'years').add(1, 'month').endOf('month');
     const startDate = this.options.startDate || defaultStartMoment.toDate();
+    const endDate = this.options.endDate || defaultEndMoment.toDate();
     const startMoment = moment.max(defaultStartMoment, moment(startDate));
+    const endMoment = moment.max(defaultEndMoment, moment(endDate));
 
     return fetchAllTransactions(this.page, {
       ...this.options,
       servicesUrl: this.servicesUrl,
       companyCode: this.companyCode,
-    }, startMoment);
+    }, startMoment, endMoment);
   }
 }
 

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -47,6 +47,11 @@ export interface ScaperOptions {
   startDate: Date;
 
   /**
+   * the date to fetch transactions to
+   */
+  endDate: Date;
+
+  /**
    * shows the browser while scraping, good for debugging (default false)
    */
   showBrowser?: boolean;

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -187,9 +187,12 @@ function prepareTransactions(txns: Transaction[], startMoment: moment.Moment, co
 
 async function fetchTransactions(page: Page, options: ScaperOptions) {
   const defaultStartMoment = moment().subtract(1, 'years');
+  const defaultEndMoment = moment().subtract(1, 'years').add(1, 'month').endOf('month');
   const startDate = options.startDate || defaultStartMoment.toDate();
+  const endDate = options.endDate || defaultEndMoment.toDate();
   const startMoment = moment.max(defaultStartMoment, moment(startDate));
-  const allMonths = getAllMonthMoments(startMoment, true);
+  const endMoment = moment.max(defaultEndMoment, moment(endDate));
+  const allMonths = getAllMonthMoments(startMoment, endMoment);
 
   let allResults: Record<string, Transaction[]> = {};
   for (let i = 0; i < allMonths.length; i += 1) {


### PR DESCRIPTION
This is a fix (enhancement) for #397 adding endDate to the scrapper options.
I tested it using Isracard and Max cards on the real websites