### PR TITLE
Removed unnecessary backticks  so code will be node-flavored

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Check the options declaration [here](./src/scrapers/base-scraper.ts) for availab
 
 Regarding credentials, you should provide the relevant credentials for the chosen company. See [this file](./src/definitions.ts) with list of credentials per company.
 
-```
 The structure of the result object is as follows:
+
 ```node
 {
   success: boolean,


### PR DESCRIPTION
This is very simple PR, just removing 3 backticks form the README file so the code block will be shown as node.