### PR TITLE
chore: restore lint status check which is blocking merges

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run npm install
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+

--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -19,5 +19,4 @@ jobs:
     - name: npm install and test
       run: |
         npm install
-        npm run lint
         npm run test:ci


### PR DESCRIPTION
@eshaham at the moment due to the orphaned status check `lint` that blocks all PRs I cannot merge approved ones like #593 

As I didn't find a way to get rid of this status check, I though maybe it is easier to just add it again so it will hopefully resolve the blocker we currently have on any PRs.