### PR TITLE
Adding Mercantile bank scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently only the following banks are supported:
 - Bank Hapoalim (thanks [@sebikaplun](https://github.com/sebikaplun))
 - Leumi Bank (thanks [@esakal](https://github.com/esakal))
 - Discount Bank
+- Mercantile Bank
 - Mizrahi Bank (thanks [@baruchiro](https://github.com/baruchiro))
 - Otsar Hahayal Bank (thanks [@matanelgabsi](https://github.com/matanelgabsi))
 - Visa Cal (thanks [@nirgin](https://github.com/nirgin))
@@ -186,6 +187,17 @@ const credentials = {
 This scraper supports fetching transaction from up to one year.
 
 ## Discount scraper
+This scraper expects the following credentials object:
+```node
+const credentials = {
+  id: <user identification number>,
+  password: <user password>,
+  num: <user identificaiton code>
+};
+```
+This scraper supports fetching transaction from up to one year (minus 1 day).
+
+## Mercantile scraper
 This scraper expects the following credentials object:
 ```node
 const credentials = {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,6 +14,7 @@ export enum CompanyTypes {
   leumiCard = 'leumiCard',
   otsarHahayal = 'otsarHahayal',
   discount = 'discount',
+  mercantile = 'mercantile',
   mizrahi = 'mizrahi',
   leumi = 'leumi',
   massad = 'massad'
@@ -38,6 +39,10 @@ export const SCRAPERS = {
   },
   [CompanyTypes.discount]: {
     name: 'Discount Bank',
+    loginFields: ['id', PASSWORD_FIELD, 'num'],
+  },
+  [CompanyTypes.mercantile]: {
+    name: 'Mercantile Bank',
     loginFields: ['id', PASSWORD_FIELD, 'num'],
   },
   [CompanyTypes.otsarHahayal]: {

--- a/src/scrapers/factory.ts
+++ b/src/scrapers/factory.ts
@@ -29,7 +29,7 @@ export default function createScraper(options: ScaperOptions) {
     case CompanyTypes.discount:
       return new DiscountScraper(options);
     case CompanyTypes.mercantile:
-      return new MercantileScraper(options);      
+      return new MercantileScraper(options);
     case CompanyTypes.otsarHahayal:
       return new OtsarHahayalScraper(options);
     case CompanyTypes.visaCal:

--- a/src/scrapers/factory.ts
+++ b/src/scrapers/factory.ts
@@ -2,6 +2,7 @@ import HapoalimScraper from './hapoalim';
 import OtsarHahayalScraper from './otsar-hahayal';
 import LeumiScraper from './leumi';
 import DiscountScraper from './discount';
+import MercantileScraper from './mercantile';
 import MaxScraper from './max';
 import VisaCalScraper from './visa-cal';
 import IsracardScraper from './isracard';
@@ -27,6 +28,8 @@ export default function createScraper(options: ScaperOptions) {
       return new MizrahiScraper(options);
     case CompanyTypes.discount:
       return new DiscountScraper(options);
+    case CompanyTypes.mercantile:
+      return new MercantileScraper(options);      
     case CompanyTypes.otsarHahayal:
       return new OtsarHahayalScraper(options);
     case CompanyTypes.visaCal:

--- a/src/scrapers/mercantile.test.ts
+++ b/src/scrapers/mercantile.test.ts
@@ -1,0 +1,53 @@
+import MercantileScraper from './mercantile';
+import {
+  maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions,
+} from '../tests/tests-utils';
+import { SCRAPERS } from '../definitions';
+import { LoginResults } from './base-scraper-with-browser';
+
+const COMPANY_ID = 'mercantile'; // TODO this property should be hard-coded in the provider
+const testsConfig = getTestsConfig();
+
+describe('Mercantile legacy scraper', () => {
+  beforeAll(() => {
+    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+  });
+
+  test('should expose login fields in scrapers constant', () => {
+    expect(SCRAPERS.mercantile).toBeDefined();
+    expect(SCRAPERS.mercantile.loginFields).toContain('id');
+    expect(SCRAPERS.mercantile.loginFields).toContain('password');
+    expect(SCRAPERS.mercantile.loginFields).toContain('num');
+  });
+
+  maybeTestCompanyAPI(COMPANY_ID, (config) => config.companyAPI.invalidPassword)('should fail on invalid user/password"', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: COMPANY_ID,
+    };
+
+    const scraper = new MercantileScraper(options);
+
+    const result = await scraper.scrape({ username: 'e10s12', password: '3f3ss3d' });
+
+    expect(result).toBeDefined();
+    expect(result.success).toBeFalsy();
+    expect(result.errorType).toBe(LoginResults.InvalidPassword);
+  });
+
+  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: COMPANY_ID,
+    };
+
+    const scraper = new MercantileScraper(options);
+    const result = await scraper.scrape(testsConfig.credentials.mercantile);
+    expect(result).toBeDefined();
+    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
+    expect(error).toBe('');
+    expect(result.success).toBeTruthy();
+
+    exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});

--- a/src/scrapers/mercantile.ts
+++ b/src/scrapers/mercantile.ts
@@ -5,7 +5,7 @@ class MercantileScraper extends DiscountScraper {
   getLoginOptions(credentials: ScraperCredentials) {
     return {
       ...super.getLoginOptions(credentials),
-      loginUrl: `https://start.telebank.co.il/apollo/core/templates/lobby/masterPage.html?bank=M`,
+      loginUrl: 'https://start.telebank.co.il/apollo/core/templates/lobby/masterPage.html?bank=M',
     };
   }
 }

--- a/src/scrapers/mercantile.ts
+++ b/src/scrapers/mercantile.ts
@@ -5,7 +5,7 @@ class MercantileScraper extends DiscountScraper {
   getLoginOptions(credentials: ScraperCredentials) {
     return {
       ...super.getLoginOptions(credentials),
-      loginUrl: `https://start.telebank.co.il/apollo/core/templates/lobby/masterPage.html?t=P&bank=M&multilang=he`,
+      loginUrl: `https://start.telebank.co.il/apollo/core/templates/lobby/masterPage.html?bank=M`,
     };
   }
 }

--- a/src/scrapers/mercantile.ts
+++ b/src/scrapers/mercantile.ts
@@ -1,0 +1,13 @@
+import DiscountScraper from './discount';
+import { ScraperCredentials } from './base-scraper';
+
+class MercantileScraper extends DiscountScraper {
+  getLoginOptions(credentials: ScraperCredentials) {
+    return {
+      ...super.getLoginOptions(credentials),
+      loginUrl: `https://start.telebank.co.il/apollo/core/templates/lobby/masterPage.html?t=P&bank=M&multilang=he`,
+    };
+  }
+}
+
+export default MercantileScraper;


### PR DESCRIPTION
As Mercantile bank using the same systems as Discount bank, It was super easy to extended the Discount scraper and support Mercantile as well, by extending the Discount scraper and adding the query string used to define the right bank to the login url.
