### PR TITLE
visa-cal: login and fetch based on dates

### DIFF
--- a/src/helpers/elements-interactions.ts
+++ b/src/helpers/elements-interactions.ts
@@ -1,6 +1,6 @@
-import { Page } from 'puppeteer';
+import {Frame, Page} from 'puppeteer';
 
-async function waitUntilElementFound(page: Page, elementSelector: string,
+async function waitUntilElementFound(page: Page | Frame, elementSelector: string,
   onlyVisible = false, timeout = 30000) {
   await page.waitForSelector(elementSelector, { visible: onlyVisible, timeout });
 }
@@ -9,16 +9,16 @@ async function waitUntilElementDisappear(page: Page, elementSelector: string, ti
   await page.waitForSelector(elementSelector, { hidden: true, timeout });
 }
 
-async function fillInput(page: Page, inputSelector: string, inputValue: string): Promise<void> {
-  await page.$eval(inputSelector, (input: Element) => {
+async function fillInput(pageOrFrame: Page | Frame, inputSelector: string, inputValue: string): Promise<void> {
+  await pageOrFrame.$eval(inputSelector, (input: Element) => {
     const inputElement = input;
     // @ts-ignore
     inputElement.value = '';
   });
-  await page.type(inputSelector, inputValue);
+  await pageOrFrame.type(inputSelector, inputValue);
 }
 
-async function clickButton(page: Page, buttonSelector: string) {
+async function clickButton(page: Page | Frame, buttonSelector: string) {
   await page.$eval(buttonSelector, (el) => (el as HTMLElement).click());
 }
 
@@ -33,10 +33,10 @@ async function clickLink(page: Page, aSelector: string) {
 }
 
 async function pageEvalAll<R>(page: Page, selector: string,
-  defaultResult: any, callback: (elements: Element[]) => R): Promise<R> {
+  defaultResult: any, callback: (elements: Element[], ...args: any) => R, ...args: any[]): Promise<R> {
   let result = defaultResult;
   try {
-    result = await page.$$eval(selector, callback);
+    result = await page.$$eval(selector, callback, ...args);
   } catch (e) {
     // TODO temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until they will release a new version.
     if (e.message.indexOf('Error: failed to find elements matching selector') !== 0) {


### PR DESCRIPTION
# Motivations
Visa cal changed the API we were using in a way that introduced too many issues.

They removed essential information making it impossible to support the API we are using.

In this PR, I'm creating a new scraper using the puppeteer library. I track the status in the list below:
- [x] login into the account
- [x] filter transactions based on the start date
- [ ] support multiple accounts
- [ ] scraper transactions and convert them to the structure used by the library API
- [ ] fix lint issues and finetune the code

closes #603, closes #602