### PR TITLE
Isracard max include next 3 months

### DIFF
--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -1,12 +1,12 @@
 import moment, { Moment } from 'moment';
 
-export default function getAllMonthMoments(startMoment: Moment | string, scrapeXFutureMonths?: number) {
+export default function getAllMonthMoments(startMoment: Moment | string, futureMonths?: number) {
   let monthMoment = moment(startMoment).startOf('month');
 
   const allMonths: Moment[] = [];
   let lastMonth = moment().startOf('month');
-  if (scrapeXFutureMonths && scrapeXFutureMonths > 0) {
-    lastMonth = lastMonth.add(scrapeXFutureMonths, 'month');
+  if (futureMonths && futureMonths > 0) {
+    lastMonth = lastMonth.add(futureMonths, 'month');
   }
   while (monthMoment.isSameOrBefore(lastMonth)) {
     allMonths.push(monthMoment);

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -1,12 +1,12 @@
 import moment, { Moment } from 'moment';
 
-export default function getAllMonthMoments(startMoment: Moment | string, includeNext: boolean) {
+export default function getAllMonthMoments(startMoment: Moment | string, scrapeXFutureMonths?: number) {
   let monthMoment = moment(startMoment).startOf('month');
 
   const allMonths: Moment[] = [];
   let lastMonth = moment().startOf('month');
-  if (includeNext) {
-    lastMonth = lastMonth.add(4, 'month');
+  if (scrapeXFutureMonths && scrapeXFutureMonths > 0) {
+    lastMonth = lastMonth.add(scrapeXFutureMonths, 'month');
   }
   while (monthMoment.isSameOrBefore(lastMonth)) {
     allMonths.push(monthMoment);

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -6,7 +6,7 @@ export default function getAllMonthMoments(startMoment: Moment | string, include
   const allMonths: Moment[] = [];
   let lastMonth = moment().startOf('month');
   if (includeNext) {
-    lastMonth = lastMonth.add(1, 'month');
+    lastMonth = lastMonth.add(4, 'month');
   }
   while (monthMoment.isSameOrBefore(lastMonth)) {
     allMonths.push(monthMoment);

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -233,7 +233,8 @@ async function fetchTransactions(page: Page, options: ExtendedScraperOptions, st
 }
 
 async function fetchAllTransactions(page: Page, options: ExtendedScraperOptions, startMoment: Moment) {
-  const allMonths = getAllMonthMoments(startMoment, true);
+  const futureMonthsToScrape = options.futureMonthsToScrape ?? 2;
+  const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
   const results: ScrapedAccountsWithIndex[] = await Promise.all(allMonths.map(async (monthMoment) => {
     return fetchTransactions(page, options, startMoment, monthMoment);
   }));

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -233,7 +233,7 @@ async function fetchTransactions(page: Page, options: ExtendedScraperOptions, st
 }
 
 async function fetchAllTransactions(page: Page, options: ExtendedScraperOptions, startMoment: Moment) {
-  const futureMonthsToScrape = options.futureMonthsToScrape ?? 2;
+  const futureMonthsToScrape = options.futureMonthsToScrape ?? 1;
   const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
   const results: ScrapedAccountsWithIndex[] = await Promise.all(allMonths.map(async (monthMoment) => {
     return fetchTransactions(page, options, startMoment, monthMoment);

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -51,6 +51,12 @@ export interface ScaperOptions {
    */
   showBrowser?: boolean;
 
+
+  /**
+   * scrape transactions to be processed X months in the future
+   */
+  futureMonthsToScrape?: number;
+
   /**
    * option from init puppeteer browser instance outside the libary scope. you can get
    * browser diretly from puppeteer via `puppeteer.launch()`

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -186,7 +186,7 @@ function prepareTransactions(txns: Transaction[], startMoment: moment.Moment, co
 }
 
 async function fetchTransactions(page: Page, options: ScaperOptions) {
-  const futureMonthsToScrape = options.futureMonthsToScrape ?? 2;
+  const futureMonthsToScrape = options.futureMonthsToScrape ?? 1;
   const defaultStartMoment = moment().subtract(1, 'years');
   const startDate = options.startDate || defaultStartMoment.toDate();
   const startMoment = moment.max(defaultStartMoment, moment(startDate));

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -186,10 +186,11 @@ function prepareTransactions(txns: Transaction[], startMoment: moment.Moment, co
 }
 
 async function fetchTransactions(page: Page, options: ScaperOptions) {
+  const futureMonthsToScrape = options.futureMonthsToScrape ?? 2;
   const defaultStartMoment = moment().subtract(1, 'years');
   const startDate = options.startDate || defaultStartMoment.toDate();
   const startMoment = moment.max(defaultStartMoment, moment(startDate));
-  const allMonths = getAllMonthMoments(startMoment, true);
+  const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
 
   let allResults: Record<string, Transaction[]> = {};
   for (let i = 0; i < allMonths.length; i += 1) {


### PR DESCRIPTION
Hi,
My payment terms in Isracard for abroad transactions are +1 month (but for some it's +3 months) from the purchase date.
This means that if I bought something in October it will not be processed in November as an ordinary domestic transaction, it will be processed at December. (see screenshot)
![image](https://user-images.githubusercontent.com/140349/139590583-aa85f0d1-b6de-4448-bfab-fdb4aa3daad9.png)

The current code scrapes transaction to be processed only one month head (November) and therefore misses the two transactions in the screenshot above even though the purchase date is in the past (it's Oct 31 at the time of opening this PR).

I've changed the code to scrape +4 months which is +1 for the next month like domestic transactions +3 for the special abroad terms...

I've tested this code both with `max` and `isracard` which are the only two usages.