### PR TITLE
[visaCal] Parse foreign currencies correctly

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,9 @@ export const SHEKEL_CURRENCY = 'ILS';
 export const DOLLAR_CURRENCY_SYMBOL = '$';
 export const DOLLAR_CURRENCY = 'USD';
 
+export const EURO_CURRENCY_SYMBOL = '€';
+export const EURO_CURRENCY = 'EUR';
+
 export const ISO_DATE_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]';
 
 export const ISO_DATE_REGEX = /^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3])(:[0-5][0-9]){2}\.[0-9]{3}Z$/;

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -104,7 +104,7 @@ function getAmountData(amountStr: string) {
     currency = EURO_CURRENCY;
   } else {
     const parts = amountStrCln.split(' ');
-    currency = parts[0];
+    [currency] = parts;
     amount = -parseFloat(parts[1]);
   }
 

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -13,7 +13,7 @@ import {
 } from '../transactions';
 import { ScaperOptions, ScaperScrapingResult, ScraperCredentials } from './base-scraper';
 import {
-  DOLLAR_CURRENCY, DOLLAR_CURRENCY_SYMBOL, SHEKEL_CURRENCY, SHEKEL_CURRENCY_SYMBOL,
+  DOLLAR_CURRENCY, DOLLAR_CURRENCY_SYMBOL, EURO_CURRENCY, EURO_CURRENCY_SYMBOL, SHEKEL_CURRENCY, SHEKEL_CURRENCY_SYMBOL,
 } from '../constants';
 import { waitUntil } from '../helpers/waiting';
 import { filterOldTransactions } from '../helpers/transactions';
@@ -99,10 +99,13 @@ function getAmountData(amountStr: string) {
   } else if (amountStrCln.includes(DOLLAR_CURRENCY_SYMBOL)) {
     amount = -parseFloat(amountStrCln.replace(DOLLAR_CURRENCY_SYMBOL, ''));
     currency = DOLLAR_CURRENCY;
+  } else if (amountStrCln.includes(EURO_CURRENCY_SYMBOL)) {
+    amount = -parseFloat(amountStrCln.replace(EURO_CURRENCY_SYMBOL, ''));
+    currency = EURO_CURRENCY;
   } else {
     const parts = amountStrCln.split(' ');
-    amount = -parseFloat(parts[0]);
-    [, currency] = parts;
+    currency = parts[0];
+    amount = -parseFloat(parts[1]);
   }
 
   return {


### PR DESCRIPTION
1. Added explicit parsing for EUR
2. Fixed parsing of amount string scraped from visa cal website.

closes https://github.com/eshaham/israeli-bank-scrapers/issues/627