### PR TITLE
Add category support

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -49,4 +49,5 @@ export interface Transaction {
   memo?: string;
   status: TransactionStatuses;
   installments?: TransactionInstallments;
+  category?: string;
 }


### PR DESCRIPTION
## Added
- Add support for an optional category for credit card transactions.
- Add categories for max transactions

## Accounts supported
- **max**: Added support

## Accounts not supported
The following accounts are accounts I have access to, but categories are not loaded with the transactions, only one by one when expanding in the UI.
- **visaCal**
- **amex**
- **isracard**

If you think its fine to call the get category endpoint for every transaction - I can try to add support for them.