### PR TITLE
[hapoalim] Fix balance error for closed accounts

### DIFF
--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -171,6 +171,10 @@ class BaseScraperWithBrowser extends BaseScraper {
       width: VIEWPORT_WIDTH,
       height: VIEWPORT_HEIGHT,
     });
+
+    this.page.on('requestfailed', (request) => {
+      debug('Request failed: %s %s', request.failure()?.errorText, request.url());
+    });
   }
 
   async navigateTo(url: string, page?: Page, timeout?: number): Promise<void> {

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -10,6 +10,9 @@ import {
   TransactionsAccount, Transaction, TransactionStatuses, TransactionTypes,
 } from '../transactions';
 import { ScaperOptions, ScraperCredentials } from './base-scraper';
+import { getDebug } from '../helpers/debug';
+
+const debug = getDebug('hapoalim');
 
 const DATE_FORMAT = 'YYYYMMDD';
 
@@ -137,7 +140,10 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScaperOpti
   const restContext = await getRestContext(page);
   const apiSiteUrl = `${baseUrl}/${restContext}`;
   const accountDataUrl = `${baseUrl}/ServerServices/general/accounts`;
+
+  debug('fetching accounts data');
   const accountsInfo = await fetchGetWithinPage<FetchedAccountData>(page, accountDataUrl) || [];
+  debug('got %d accounts, fetching txns and balance', accountsInfo.length);
 
   const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
   const startDate = options.startDate || defaultStartMoment.toDate();
@@ -173,7 +179,7 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScaperOpti
     success: true,
     accounts,
   };
-
+  debug('fetching ended');
   return accountData;
 }
 


### PR DESCRIPTION
- Fixes #640 by skipping the balance checking for closed accounts.
- Added logs for failed requests.
- Added logs for hapoalim scraper.
- Separated code functions for ease of reading.