### PR TITLE
Leumi: Init milliseconds in Leumi's date

### DIFF
--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -69,11 +69,12 @@ function extractTransactionsFromPage(transactions: any[], status: TransactionSta
   }
 
   const result: Transaction[] = transactions.map((rawTransaction) => {
+    const date = moment(rawTransaction.DateUTC).milliseconds(0).toISOString();
     const newTransaction: Transaction = {
       status,
       type: TransactionTypes.Normal,
-      date: rawTransaction.DateUTC,
-      processedDate: rawTransaction.DateUTC,
+      date,
+      processedDate: date,
       description: rawTransaction.Description || '',
       identifier: rawTransaction.ReferenceNumberLong,
       memo: rawTransaction.AdditionalData || '',


### PR DESCRIPTION
For some reason Leumi's dates has 3 milliseconds (at least for my case). I just change the milliseconds to 0 in order to fix that