### PR TITLE
Add support to config timeout

### DIFF
--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -138,6 +138,7 @@ class BaseScraperWithBrowser extends BaseScraper {
     } else {
       const executablePath = this.options.executablePath || undefined;
       const args = this.options.args || [];
+      const { timeout } = this.options;
 
       const headless = !this.options.showBrowser;
       debug(`launch a browser with headless mode = ${headless}`);
@@ -146,6 +147,7 @@ class BaseScraperWithBrowser extends BaseScraper {
         headless,
         executablePath,
         args,
+        timeout,
       });
     }
 

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -92,6 +92,12 @@ export interface ScraperOptions {
   args?: string[];
 
   /**
+   * Maximum navigation time in milliseconds, pass 0 to disable timeout.
+   * @default 30000
+   */
+  timeout?: number | undefined;
+
+  /**
    * adjust the browser instance before it is being used
    *
    * @param browser


### PR DESCRIPTION
In order to support slow end devices, I added the ability to configure timeout.
No breaking change - when leaving empty (undefined) it will use the previous undefined value, which result in 30s default. 