### PR TITLE
Add the ability to get extra data from transaction (for now - category) from isracard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Any kind of help is welcome, even if you just discover an issue and don't have t
 While there's no specific template for creating a new issue, please take the time to create a clear description so that it is easy to understand the problem.
 
 ## Testing the scrapers
-In order to run tests you need first to create test configuration file `./src/tests/tests-config.js` from template `./src/tests/tests-config.tpl.js`. This file will be used by `jest` testing framework. 
+In order to run tests you need first to create test configuration file `./src/tests/.tests-config.js` from template `./src/tests/.tests-config.tpl.js`. This file will be used by `jest` testing framework. 
 
 > IMPORTANT: Under `src/tests` folder exists `.gitignore` file that ignore the test configuration file thus this file will not be commited to github. Still when you create new PRs make sure that you didn't explicitly added it to the PR.
 

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -43,3 +43,7 @@ export function raceTimeout(ms: number, promise: Promise<any>) {
     if (!(err instanceof TimeoutError)) throw err;
   });
 }
+
+export function runSerial<T>(actions: (() => Promise<T>)[]): Promise<T[]> {
+  return actions.reduce((m, a) => m.then(async (x) => [...x, await a()]), Promise.resolve<T[]>(new Array<T>()));
+}

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -125,6 +125,12 @@ export interface ScraperOptions {
    * Options for manipulation of output data
    */
   outputData?: OutputDataOptions;
+
+  /**
+   * Perform additional operation for each transaction to get more information (Like category) about it.
+   * Please note: It will take more time to finish the process.
+   */
+  additionalTransactionInformation?: boolean;
 }
 
 export interface OutputDataOptions {


### PR DESCRIPTION
Add the ability to get extra data from transaction (for now - category) from isracard
By providing `extraScrap = true` in options

#740