### PR TITLE
Otsar hahayal: Fixed login by waiting 1 second

### DIFF
--- a/src/scrapers/otsar-hahayal.ts
+++ b/src/scrapers/otsar-hahayal.ts
@@ -203,7 +203,10 @@ class OtsarHahayalScraper extends BaseScraperWithBrowser {
     return {
       loginUrl: `${BASE_URL}/MatafLoginService/MatafLoginServlet?bankId=OTSARPRTAL&site=Private&KODSAFA=HE`,
       fields: createLoginFields(credentials),
-      submitButtonSelector: '#continueBtn',
+      submitButtonSelector: async () => {
+        await this.page.waitForTimeout(1000);
+        await clickButton(this.page, '#continueBtn');
+      },
       postAction: async () => waitForPostLogin(this.page),
       possibleResults: getPossibleLoginResults(this.page),
     };


### PR DESCRIPTION
The current login flow fails. It seems the browser isn't really clicking
the button.
Tried switching to another button clicking method but didn't work,
neither waiting for the button (as it was already there).

I'm not proud of arbitrary sleeps, but it seems that waiting for a
second magically solves everything.

Tests:
```
npm install
npm exec cross-env BABEL_ENV=test jest --testRegexp '.*Otsar.*'
```
