### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
GitHub runners for `ubuntu-18.04` are not available, causing the workflow to hang with "Waiting for a runner to pick up this job..."

See hanging job here: https://github.com/eshaham/israeli-bank-scrapers/actions/runs/4746453978/jobs/8430124345