### PR TITLE
Replace the `Scraper` type with `BaseScraper`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,10 @@ export {
   ScraperScrapingResult,
   ScraperLoginResult as ScaperLoginResult,
   ScraperLoginResult,
-  Scraper,
   ScraperCredentials,
 } from './scrapers/interface';
+
+export type { BaseScraper as Scraper } from './scrapers/base-scraper';
 
 export { default as OneZeroScraper } from './scrapers/one-zero';
 

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -3,7 +3,6 @@ import moment from 'moment-timezone';
 import { TimeoutError } from '../helpers/waiting';
 import { createGenericError, createTimeoutError } from './errors';
 import {
-  Scraper,
   ScraperCredentials,
   ScraperGetLongTermTwoFactorTokenResult,
   ScraperLoginResult,
@@ -26,7 +25,7 @@ export enum ScraperProgressTypes {
   Terminating = 'TERMINATING',
 }
 
-export class BaseScraper<TCredentials extends ScraperCredentials> implements Scraper<TCredentials> {
+export class BaseScraper<TCredentials extends ScraperCredentials> {
   private eventEmitter = new EventEmitter();
 
   constructor(public options: ScraperOptions) {

--- a/src/scrapers/factory.test.ts
+++ b/src/scrapers/factory.test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { CompanyTypes } from '../definitions';
+import createScraper from './factory';
+
+describe('Factory', () => {
+  test('should return a scraper instance', () => {
+    const scraper = createScraper({
+      companyId: CompanyTypes.hapoalim,
+      startDate: new Date(),
+    });
+    expect(scraper).toBeDefined();
+
+    // This will also check that the type returned is a BaseScraper
+    expect(scraper.scrape).toBeInstanceOf(Function);
+    expect(scraper.onProgress).toBeInstanceOf(Function);
+  });
+});

--- a/src/scrapers/factory.ts
+++ b/src/scrapers/factory.ts
@@ -11,12 +11,13 @@ import UnionBankScraper from './union-bank';
 import BeinleumiScraper from './beinleumi';
 import MassadScraper from './massad';
 import YahavScraper from './yahav';
-import { Scraper, ScraperCredentials, ScraperOptions } from './interface';
+import { BaseScraper } from './base-scraper';
+import { ScraperCredentials, ScraperOptions } from './interface';
 import { CompanyTypes } from '../definitions';
 import BeyahadBishvilhaScraper from './beyahad-bishvilha';
 import OneZeroScraper from './one-zero';
 
-export default function createScraper(options: ScraperOptions): Scraper<ScraperCredentials> {
+export default function createScraper(options: ScraperOptions): BaseScraper<ScraperCredentials> {
   switch (options.companyId) {
     case CompanyTypes.hapoalim:
       return new HapoalimScraper(options);

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -135,10 +135,6 @@ export interface ScraperScrapingResult {
   errorMessage?: string; // only on success=false
 }
 
-export interface Scraper<TCredentials extends ScraperCredentials> {
-  scrape(credentials: TCredentials): Promise<ScraperScrapingResult>;
-}
-
 export type ScraperTwoFactorAuthTriggerResult = ErrorResult | {
   success: true;
 };


### PR DESCRIPTION
In https://github.com/eshaham/israeli-bank-scrapers/pull/760 the signature of  `createScraper` changed -
```diff
- export default function createScraper(options: ScraperOptions) {
+ export default function createScraper(options: ScraperOptions): Scraper<ScraperCredentials> {
```

```ts
export interface Scraper<TCredentials extends ScraperCredentials> {
  scrape(credentials: TCredentials): Promise<ScraperScrapingResult>;
}
```

Since the new interface has only the `scrape` method, the following error is emitted when accessing methods of `BaseScraper` like `onProgress`:
```
error TS2339: Property 'onProgress' does not exist on type 'Scraper<ScraperCredentials>'.
     scraper.onProgress((companyId, { type }) => {
```

Looking at the code, seems that there is no special reason to define a separate interface for the base class for all scrapers.
Removing the Scraper interface solves the existing problem + ensures all existing and future fields will be available in the type returned from `createScraper`

Fixes #772