### PR TITLE
[visaCal] Use waitUntil to retry getting init data

### DIFF
--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -5,7 +5,7 @@ export class TimeoutError extends Error {
 
 export const SECOND = 1000;
 
-function timeoutPromise(ms: number, promise: Promise<any>, description: string) {
+function timeoutPromise<T>(ms: number, promise: Promise<T>, description: string): Promise<T> {
   const timeout = new Promise((_, reject) => {
     const id = setTimeout(() => {
       clearTimeout(id);
@@ -16,16 +16,20 @@ function timeoutPromise(ms: number, promise: Promise<any>, description: string) 
 
   return Promise.race([
     promise,
-    timeout,
+    // casting to avoid type error- safe since this promise will always reject
+    timeout as Promise<T>,
   ]);
 }
 
-export function waitUntil(asyncTest: () => Promise<any>, description = '', timeout = 10000, interval = 100) {
-  const promise = new Promise((resolve, reject) => {
+/**
+ * Wait until a promise resolves with a truthy value or reject after a timeout
+ */
+export function waitUntil<T>(asyncTest: () => Promise<T>, description = '', timeout = 10000, interval = 100) {
+  const promise = new Promise<T>((resolve, reject) => {
     function wait() {
       asyncTest().then((value) => {
-        if (value === true) {
-          resolve();
+        if (value) {
+          resolve(value);
         } else {
           setTimeout(wait, interval);
         }

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -251,7 +251,12 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
   };
 
   async getCards() {
-    const initData = await getFromSessionStorage<InitResponse>(this.page, 'init');
+    const initData = await waitUntil(
+      () => getFromSessionStorage<InitResponse>(this.page, 'init'),
+      'get init data in session storage',
+      10_000,
+      1000,
+    );
     if (!initData) {
       throw new Error('could not find \'init\' data in session storage');
     }
@@ -321,8 +326,6 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     debug(`fetch transactions starting ${startMoment.format()}`);
 
     const Authorization = await this.getAuthorizationHeader();
-    // Wait a little before `this.getCards` so that it would exist
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     const cards = await this.getCards();
     const xSiteId = await this.getXSiteId();
 


### PR DESCRIPTION
Sometimes the visaCal scraper fails with `"could not find 'init' data in session storage"`.
This is caused since the site might take more time to init.