### PR TITLE
Fixed new cal api amount field

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -197,7 +197,7 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
 
       // I didn't test `amtBeforeConvAndIndex` with a foreign currency as I don't have such transactions
       let chargedAmount: number;
-      if (cardAndTransactionCurrencySymbolIsShekel(transaction)) {
+      if (!cardAndTransactionCurrencySymbolIsShekel(transaction)) {
         chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
       } else {
         chargedAmount = transaction.trnAmt * (-1);

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import { Frame, Page } from 'puppeteer';
 
-import { SHEKEL_CURRENCY_SYMBOL } from '../constants';
 import { getDebug } from '../helpers/debug';
 import {
   clickButton, elementPresentOnPage, pageEval, waitUntilElementFound,
@@ -176,10 +175,6 @@ function createLoginFields(credentials: ScraperSpecificCredentials) {
   ];
 }
 
-function cardAndTransactionCurrencySymbolIsShekel(transaction: ScrapedTransaction) {
-  return transaction.debCrdCurrencySymbol === SHEKEL_CURRENCY_SYMBOL &&
-    transaction.trnCurrencySymbol === SHEKEL_CURRENCY_SYMBOL;
-}
 function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): Transaction[] {
   return parsedData
     .flatMap((monthData) => monthData.result.bankAccounts)
@@ -195,22 +190,18 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
 
       const date = moment(transaction.trnPurchaseDate);
 
-      // I didn't test `amtBeforeConvAndIndex` with a foreign currency as I don't have such transactions
-      let chargedAmount: number;
-      if (!cardAndTransactionCurrencySymbolIsShekel(transaction)) {
-        chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
-      } else {
-        chargedAmount = transaction.trnAmt * (-1);
+      let chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
+      let originalAmount = transaction.trnAmt * (-1);
 
-        if (transaction.trnTypeCode === trnTypeCode.credit) {
-          chargedAmount = transaction.trnAmt;
-        }
+      if (transaction.trnTypeCode === trnTypeCode.credit) {
+        chargedAmount = transaction.amtBeforeConvAndIndex;
+        originalAmount = transaction.trnAmt;
       }
 
       const result: Transaction = {
         chargedAmount,
         description: transaction.merchantName,
-        originalAmount: transaction.amtBeforeConvAndIndex,
+        originalAmount,
         originalCurrency: transaction.trnCurrencySymbol,
         processedDate: transaction.debCrdDate,
         status: TransactionStatuses.Completed,


### PR DESCRIPTION
The CAL scraper is currently mixing up the converted amount and original amount in foreign transactions
Here's some real life data:
![image](https://user-images.githubusercontent.com/1201448/233503024-d748a642-bd37-4912-9c31-ae6b3c4381cd.png)
```json
{
  ...
  "merchantName": "RYANAIR",
  "trnAmt": 175.09,
  "trnCurrencySymbol": "€",
  "trnType": "רגילה",
  "trnTypeCode": "5",
  "amtBeforeConvAndIndex": 664.38,
  "debCrdCurrencySymbol": "₪",
  "comments": [
    {
      "key": "סכום הנחה בעמלת עסקאות מט\"ח",
      "value": "11.84"
    },
    {
      "key": "עמלת עסקת מט\"ח",
      "value": "18.42"
    },
    {
      "key": "עסקה עם הנחה בעמלת מט\"ח",
      "value": ""
    },
    {
      "key": "בתאריך 01/02/2023 בוצעה המרה ל-₪ בשער יציג 3.757",
      "value": ""
    }
  ],
  "transTypeCommentDetails": [
    "סכום העסקה - €175.09"
  ],
  ...
}

```
I don't blame the code, that's a VERY confusing api 😆 
@baruchiro can you please take a look? 😄 