### PR TITLE
Visa Cal wrong day of transaction, and missing fields 

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -199,20 +199,21 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
       }
 
       const result: Transaction = {
-        chargedAmount,
         identifier: transaction.trnIntId,
-        description: transaction.merchantName,
-        originalAmount,
-        originalCurrency: transaction.trnCurrencySymbol,
-        processedDate: new Date(transaction.debCrdDate).toISOString(),
+        type: [trnTypeCode.regular, trnTypeCode.standingOrder].includes(transaction.trnTypeCode) ?
+          TransactionTypes.Normal :
+          TransactionTypes.Installments,
         status: TransactionStatuses.Completed,
         date: installments ?
           date.add(installments.number - 1, 'month').toISOString() :
           date.toISOString(),
-        type: [trnTypeCode.regular, trnTypeCode.standingOrder].includes(transaction.trnTypeCode) ?
-          TransactionTypes.Normal :
-          TransactionTypes.Installments,
-        memo: transaction.transTypeCommentDetails.toString() || undefined,
+        processedDate: new Date(transaction.debCrdDate).toISOString(),
+        originalAmount,
+        originalCurrency: transaction.trnCurrencySymbol,
+        chargedAmount,
+        chargedCurrency: transaction.debCrdCurrencySymbol,
+        description: transaction.merchantName,
+        memo: transaction.transTypeCommentDetails.toString(),
         category: transaction.branchCodeDesc,
       };
 

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -204,7 +204,7 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
         description: transaction.merchantName,
         originalAmount,
         originalCurrency: transaction.trnCurrencySymbol,
-        processedDate: transaction.debCrdDate,
+        processedDate: new Date(transaction.debCrdDate).toISOString(),
         status: TransactionStatuses.Completed,
         date: installments ?
           date.add(installments.number - 1, 'month').toISOString() :


### PR DESCRIPTION
Fixes #781 (I hope)

- Date need to be formatted to ISO date, fixed for `processedDate`.
- Reorder fields just to be aligned with the previous version of Cal.
- Added field: `chargedCurrency`.