### PR TITLE
Mizrahi: Repaired balance / account number reading

### DIFF
--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -27,8 +27,7 @@ interface ScrapedTransactionsResult {
   };
   body: {
     fields: {
-      AccountNumber: string;
-      YitraLeloChekim: string;
+      Yitra: string;
     };
     table: {
       rows: ScrapedTransaction[];
@@ -212,6 +211,10 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     await waitUntilElementFound(this.page, `a[href*="${TRANSACTIONS_PAGE}"]`);
     await this.page.$eval(`a[href*="${TRANSACTIONS_PAGE}"]`, (el) => (el as HTMLElement).click());
 
+    const accountNumberElement = (await this.page.$$('#AccountPicker b'))[0];
+    const accountNumberHandle = await accountNumberElement.getProperty('title');
+    const accountNumber = ((await accountNumberHandle.jsonValue()) as string);
+
     const response = await Promise.any(TRANSACTIONS_REQUEST_URLS.map(async (url) => {
       const request = await this.page.waitForRequest(url);
       const data = createDataFromRequest(request, this.options.startDate);
@@ -236,9 +239,9 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     const allTxn = oshTxnAfterStartDate.concat(pendingTxn);
 
     return {
-      accountNumber: response.body.fields.AccountNumber,
+      accountNumber,
       txns: allTxn,
-      balance: +response.body.fields.YitraLeloChekim,
+      balance: +response.body.fields.Yitra,
     };
   }
 }


### PR DESCRIPTION
Summary:
The good people at Mizrahi changed their field structure. The account number needs to be read from pure HTML now, and "YitraLeloChekim" is gone, so I'm moving to "Yitra"

Test Plan:
BEFORE my change, testing on my Mizrahi account resulted in:
```
"account","balance","type","identifier","date","processedDate","originalAmount","originalCurrency","chargedAmount","description","status"
,"account balance: NaN","normal",18813,"09/08/2023","09/08/2023",-99999,"ILS",-999999,"העברת יומן","completed"
,"account balance: NaN","normal",99210,"08/08/2023","08/08/2023",999999,"ILS",999999,"<200f>משכורת (י)","completed"
```
AFTER:
```
"account","balance","type","identifier","date","processedDate","originalAmount","originalCurrency","chargedAmount","description","status"
"999-999999","account balance: 99999.9","normal",18813,"09/08/2023","09/08/2023",-99999,"ILS",-9999.9,"העברת יומן","completed"
"999-999999","account balance: 99999.9","normal",99210,"08/08/2023","08/08/2023",999999,"ILS",999999,"<200f>משכורת (י)","completed"
```