### PR TITLE
fix: Visa Cal - add missing transactions and fix the amount sign in case of credit (refund)

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -176,9 +176,15 @@ function createLoginFields(credentials: ScraperSpecificCredentials) {
 }
 
 function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): Transaction[] {
-  return parsedData
+  const bankAccounts = parsedData
     .flatMap((monthData) => monthData.result.bankAccounts)
+
+  const regularDebitDays = bankAccounts
     .flatMap((accounts) => accounts.debitDates)
+  const immediateDebitDays = bankAccounts
+    .flatMap((accounts) =>  accounts.immidiateDebits.debitDays)
+
+  return [...regularDebitDays, ...immediateDebitDays]
     .flatMap((debitDate) => debitDate.transactions)
     .map((transaction) => {
       const installments = (transaction.curPaymentNum && transaction.numOfPayments &&
@@ -192,11 +198,6 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
 
       let chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
       let originalAmount = transaction.trnAmt * (-1);
-
-      if (transaction.trnTypeCode === trnTypeCode.credit) {
-        chargedAmount = transaction.amtBeforeConvAndIndex;
-        originalAmount = transaction.trnAmt;
-      }
 
       const result: Transaction = {
         identifier: transaction.trnIntId,


### PR DESCRIPTION
Fixes #807 
This PR fix 2 issues with Visa Cal scraper:

1. In case of credits (refund) the "amount" field is still in minus instead of plus.
2. The scraper ignored the "immidiateDebits" field that may contains additional transactions

![image](https://github.com/eshaham/israeli-bank-scrapers/assets/4281742/0b7fe37d-0b09-4d9d-8287-5014803b8814)
