### PR TITLE
Support waitUntil parameter for puppeteer - Max scraper issue

### DIFF
--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -170,7 +170,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     });
   }
 
-  async navigateTo(url: string, page?: Page, timeout?: number,waitUntil: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2' | undefined = 'load' ): Promise<void> {
+  async navigateTo(url: string, page?: Page, timeout?: number,waitUntil: LoadEvent | undefined = 'load'): Promise<void> {
     const pageToUse = page || this.page;
 
     if (!pageToUse) {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -1,4 +1,6 @@
-import puppeteer, { Browser, Frame, Page } from 'puppeteer';
+import puppeteer, {
+  Browser, Frame, Page, LoadEvent,
+} from 'puppeteer';
 
 import {
   BaseScraper,
@@ -170,14 +172,14 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     });
   }
 
-  async navigateTo(url: string, page?: Page, timeout?: number,waitUntil: LoadEvent | undefined = 'load'): Promise<void> {
+  async navigateTo(url: string, page?: Page, timeout?: number, waitUntil: LoadEvent | undefined = 'load'): Promise<void> {
     const pageToUse = page || this.page;
 
     if (!pageToUse) {
       return;
     }
 
-    const options = { ...(timeout === null ? null : { timeout }) , waitUntil};
+    const options = { ...(timeout === null ? null : { timeout }), waitUntil };
     const response = await pageToUse.goto(url, options);
 
     // note: response will be null when navigating to same url while changing the hash part. the condition below will always accept null as valid result.

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -48,7 +48,7 @@ export interface LoginOptions {
   postAction?: () => Promise<void>;
   possibleResults: PossibleLoginResults;
   userAgent?: string;
-  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+  waitUntil?: LoadEvent;
 }
 
 async function getKeyByValue(object: PossibleLoginResults, value: string, page: Page): Promise<LoginResults> {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -218,7 +218,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     }
 
     debug('navigate to login url');
-    await this.navigateTo(loginOptions.loginUrl,undefined,undefined,loginOptions.waitUntil);
+    await this.navigateTo(loginOptions.loginUrl, undefined, undefined, loginOptions.waitUntil);
     if (loginOptions.checkReadiness) {
       debug('execute \'checkReadiness\' interceptor provided in login options');
       await loginOptions.checkReadiness();

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -48,6 +48,7 @@ export interface LoginOptions {
   postAction?: () => Promise<void>;
   possibleResults: PossibleLoginResults;
   userAgent?: string;
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
 }
 
 async function getKeyByValue(object: PossibleLoginResults, value: string, page: Page): Promise<LoginResults> {
@@ -169,14 +170,14 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     });
   }
 
-  async navigateTo(url: string, page?: Page, timeout?: number): Promise<void> {
+  async navigateTo(url: string, page?: Page, timeout?: number,waitUntil: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2' | undefined = 'load' ): Promise<void> {
     const pageToUse = page || this.page;
 
     if (!pageToUse) {
       return;
     }
 
-    const options = { ...(timeout === null ? null : { timeout }) };
+    const options = { ...(timeout === null ? null : { timeout }) , waitUntil};
     const response = await pageToUse.goto(url, options);
 
     // note: response will be null when navigating to same url while changing the hash part. the condition below will always accept null as valid result.
@@ -217,7 +218,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     }
 
     debug('navigate to login url');
-    await this.navigateTo(loginOptions.loginUrl);
+    await this.navigateTo(loginOptions.loginUrl,undefined,undefined,loginOptions.waitUntil);
     if (loginOptions.checkReadiness) {
       debug('execute \'checkReadiness\' interceptor provided in login options');
       await loginOptions.checkReadiness();

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -291,7 +291,7 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
       },
       postAction: async () => redirectOrDialog(this.page),
       possibleResults: getPossibleLoginResults(this.page),
-      waitUntil: 'domcontentloaded' as 'domcontentloaded',
+      waitUntil: 'domcontentloaded',
     };
   }
 

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -291,6 +291,7 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
       },
       postAction: async () => redirectOrDialog(this.page),
       possibleResults: getPossibleLoginResults(this.page),
+      waitUntil: 'domcontentloaded' as 'domcontentloaded',
     };
   }
 

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -1,6 +1,6 @@
 import buildUrl from 'build-url';
 import moment, { Moment } from 'moment';
-import { Page } from 'puppeteer';
+import { Page, LoadEvent } from 'puppeteer';
 import { fetchGetWithinPage } from '../helpers/fetch';
 import { BaseScraperWithBrowser, LoginResults, PossibleLoginResults } from './base-scraper-with-browser';
 import { waitForRedirect } from '../helpers/navigation';
@@ -291,7 +291,7 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
       },
       postAction: async () => redirectOrDialog(this.page),
       possibleResults: getPossibleLoginResults(this.page),
-      waitUntil: 'domcontentloaded',
+      waitUntil: 'domcontentloaded' as LoadEvent,
     };
   }
 


### PR DESCRIPTION
Hi 
I had an issue with Max scraper that stuck on scraping the login page in the last week.
When I did the debug, I saw that there was one request that got a time-out and stuck the scraping process on navigateTo function, which calls goto function of Puppeteer.
To fix that, there is a flag for Puppeteer when the  DOM document loaded content is finished - https://pptr.dev/api/puppeteer.puppeteerlifecycleevent, and when I used that it's fixes the issue.
So, I added support for waitUntil parameter from the scraper.

 

