### PR TITLE
[behatsdaa] Fix amount to be negative

### DIFF
--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -33,7 +33,6 @@ type PurchaseHistoryResponse = {
 
 function variantToTransaction(variant: Variant): Transaction {
   const originalAmount = -variant.customerPrice;
-  
   return {
     type: TransactionTypes.Normal,
     identifier: variant.tTransactionID,

--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -33,6 +33,7 @@ type PurchaseHistoryResponse = {
 
 function variantToTransaction(variant: Variant): Transaction {
   const originalAmount = -variant.customerPrice;
+  
   return {
     type: TransactionTypes.Normal,
     identifier: variant.tTransactionID,

--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -32,6 +32,7 @@ type PurchaseHistoryResponse = {
 };
 
 function variantToTransaction(variant: Variant): Transaction {
+  // The price is positive, make it negative as it's an expense
   const originalAmount = -variant.customerPrice;
   return {
     type: TransactionTypes.Normal,

--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -32,14 +32,15 @@ type PurchaseHistoryResponse = {
 };
 
 function variantToTransaction(variant: Variant): Transaction {
+  const originalAmount = -variant.customerPrice;
   return {
     type: TransactionTypes.Normal,
     identifier: variant.tTransactionID,
     date: moment(variant.orderDate).format('YYYY-MM-DD'),
     processedDate: moment(variant.orderDate).format('YYYY-MM-DD'),
-    originalAmount: variant.customerPrice,
+    originalAmount,
     originalCurrency: 'ILS',
-    chargedAmount: variant.customerPrice,
+    chargedAmount: originalAmount,
     chargedCurrency: 'ILS',
     description: variant.name,
     status: TransactionStatuses.Completed,

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -177,12 +177,12 @@ function createLoginFields(credentials: ScraperSpecificCredentials) {
 
 function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): Transaction[] {
   const bankAccounts = parsedData
-    .flatMap((monthData) => monthData.result.bankAccounts)
+    .flatMap((monthData) => monthData.result.bankAccounts);
 
   const regularDebitDays = bankAccounts
-    .flatMap((accounts) => accounts.debitDates)
+    .flatMap((accounts) => accounts.debitDates);
   const immediateDebitDays = bankAccounts
-    .flatMap((accounts) =>  accounts.immidiateDebits.debitDays)
+    .flatMap((accounts) => accounts.immidiateDebits.debitDays);
 
   return [...regularDebitDays, ...immediateDebitDays]
     .flatMap((debitDate) => debitDate.transactions)
@@ -196,8 +196,8 @@ function convertParsedDataToTransactions(parsedData: CardTransactionDetails[]): 
 
       const date = moment(transaction.trnPurchaseDate);
 
-      let chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
-      let originalAmount = transaction.trnAmt * (-1);
+      const chargedAmount = transaction.amtBeforeConvAndIndex * (-1);
+      const originalAmount = transaction.trnAmt * (-1);
 
       const result: Transaction = {
         identifier: transaction.trnIntId,


### PR DESCRIPTION
The current implementation of the scraper takes the amount from the `customerPrice` field returned from the behatsdaa api result,  which has the charged amount as a positive number.

This PR makes it negative as it's an expense