### PR TITLE
[Max] Add funds transfer support

### DIFF
--- a/src/scrapers/max.test.ts
+++ b/src/scrapers/max.test.ts
@@ -1,4 +1,4 @@
-import MaxScraper from './max';
+import MaxScraper, { getMemo } from './max';
 import {
   maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions,
 } from '../tests/tests-utils';
@@ -48,5 +48,18 @@ describe('Max scraper', () => {
     expect(result.success).toBeTruthy();
 
     exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});
+
+describe('getMemo', () => {
+  type TransactionForMemoTest = Parameters<typeof getMemo>[0];
+  test.each<[TransactionForMemoTest, string]>([
+    [{ comments: '' }, ''],
+    [{ comments: 'comment without funds' }, 'comment without funds'],
+    [{ comments: '', fundsTransferReceiverOrTransfer: 'Daniel H' }, 'Daniel H'],
+    [{ comments: '', fundsTransferReceiverOrTransfer: 'Daniel', fundsTransferComment: 'Foo bar' }, 'Daniel: Foo bar'],
+  ])('%o should create memo: %s', (transaction, expected) => {
+    const memo = getMemo(transaction);
+    expect(memo).toBe(expected);
   });
 });

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -14,7 +14,7 @@ import { SHEKEL_CURRENCY, DOLLAR_CURRENCY, EURO_CURRENCY } from '../constants';
 
 const debug = getDebug('max');
 
-interface ScrapedTransaction {
+export interface ScrapedTransaction {
   shortCardNumber: string;
   paymentDate?: string;
   purchaseDate: string;
@@ -180,16 +180,13 @@ function getChargedCurrency(currencyId: number | null) {
   }
 }
 
-function getMemo(rawTransaction: ScrapedTransaction) {
-  let memo = rawTransaction.comments;
-  if (rawTransaction.fundsTransferReceiverOrTransfer) {
-    memo += ` ${rawTransaction.fundsTransferReceiverOrTransfer}`;
-    if (rawTransaction.fundsTransferComment) {
-      memo += `: ${rawTransaction.fundsTransferComment}`;
-    }
+export function getMemo({ comments, fundsTransferReceiverOrTransfer, fundsTransferComment }: Pick<ScrapedTransaction, 'comments'| 'fundsTransferReceiverOrTransfer' | 'fundsTransferComment'>) {
+  if (fundsTransferReceiverOrTransfer) {
+    const memo = `${comments} ${fundsTransferReceiverOrTransfer}`.trim();
+    return fundsTransferComment ? `${memo}: ${fundsTransferComment}` : memo;
   }
 
-  return memo;
+  return comments;
 }
 
 function mapTransaction(rawTransaction: ScrapedTransaction): Transaction {

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -27,6 +27,8 @@ interface ScrapedTransaction {
   comments: string;
   merchantName: string;
   categoryId: number;
+  fundsTransferComment?: string;
+  fundsTransferReceiverOrTransfer?: string;
   dealData?: {
     arn: string;
   };
@@ -178,6 +180,18 @@ function getChargedCurrency(currencyId: number | null) {
   }
 }
 
+function getMemo(rawTransaction: ScrapedTransaction) {
+  let memo = rawTransaction.comments;
+  if (rawTransaction.fundsTransferReceiverOrTransfer) {
+    memo += ` ${rawTransaction.fundsTransferReceiverOrTransfer}`;
+    if (rawTransaction.fundsTransferComment) {
+      memo += `: ${rawTransaction.fundsTransferComment}`;
+    }
+  }
+
+  return memo;
+}
+
 function mapTransaction(rawTransaction: ScrapedTransaction): Transaction {
   const isPending = rawTransaction.paymentDate === null;
   const processedDate = moment(isPending ?
@@ -199,7 +213,7 @@ function mapTransaction(rawTransaction: ScrapedTransaction): Transaction {
     chargedAmount: -rawTransaction.actualPaymentAmount,
     chargedCurrency: getChargedCurrency(rawTransaction.paymentCurrency),
     description: rawTransaction.merchantName.trim(),
-    memo: rawTransaction.comments,
+    memo: getMemo(rawTransaction),
     category: categories.get(rawTransaction?.categoryId),
     installments,
     identifier,

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -180,9 +180,11 @@ function getChargedCurrency(currencyId: number | null) {
   }
 }
 
-export function getMemo({ comments, fundsTransferReceiverOrTransfer, fundsTransferComment }: Pick<ScrapedTransaction, 'comments'| 'fundsTransferReceiverOrTransfer' | 'fundsTransferComment'>) {
+export function getMemo({
+  comments, fundsTransferReceiverOrTransfer, fundsTransferComment,
+}: Pick<ScrapedTransaction, 'comments'| 'fundsTransferReceiverOrTransfer' | 'fundsTransferComment'>) {
   if (fundsTransferReceiverOrTransfer) {
-    const memo = `${comments} ${fundsTransferReceiverOrTransfer}`.trim();
+    const memo = comments ? `${comments} ${fundsTransferReceiverOrTransfer}` : fundsTransferReceiverOrTransfer;
     return fundsTransferComment ? `${memo}: ${fundsTransferComment}` : memo;
   }
 


### PR DESCRIPTION
## Change

When sending/receiving money in apps like bit/PayBox, the sender/receiver's name (and the comment in PayBox) will not be included in the memo, but in 2 other fields: `fundsTransferComment` and `fundsTransferReceiverOrTransfer`.

This PR adds both fields to the memo.
