### PR TITLE
ci: add conventional commit validation to the pr title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,18 @@
+name: Validate Conventional Commit title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install commitlint
+        run: npm install -g @commitlint/cli @commitlint/config-angular
+      - name: config commitlint
+        run: |
+          echo "module.exports = {extends: ['@commitlint/config-angular']}" > commitlint.config.js
+      - name: validate PR title
+        run: |
+          echo ${{ github.event.pull_request.title }} | commitlint


### PR DESCRIPTION
This workflow will check the PR title to match the Angular conventional commits (which is used by `semantic-release`).

In the repo setting, we set the squash commit to take the message from the title of the PR as is.