### PR TITLE
fix: changed discount scraper default start date

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -75,7 +75,7 @@ async function fetchAccountData(page: Page, options: ScraperOptions): Promise<Sc
   }
   const accountNumber = accountInfo.UserAccountsData.DefaultAccountNumber;
 
-  const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
+  const defaultStartMoment = moment().subtract(1, 'years').add(2, 'day');
   const startDate = options.startDate || defaultStartMoment.toDate();
   const startMoment = moment.max(defaultStartMoment, moment(startDate));
 


### PR DESCRIPTION
Fixes: #839 
Fix default start date of discount (and mercantile) scrapers.

The previous default date `moment().subtract(1, 'years').add(1, 'day').toDate()` would return the following error:

```
Error: GENERIC - כרגע לא ניתן להציג את המידע. אפשר לנסות שוב מאוחר יותר או לפנות למוקד התמיכה בטלפון: 03-9439191 ובטלבנק 6111*
```
changing the default start date to `moment().subtract(1, 'years').add(2, 'day').toDate()` avoids this error 