### PR TITLE
Behatsdaa txns should be positive if expenses, same as the rest of the cards

### DIFF
--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -32,8 +32,7 @@ type PurchaseHistoryResponse = {
 };
 
 function variantToTransaction(variant: Variant): Transaction {
-  // The price is positive, make it negative as it's an expense
-  const originalAmount = -variant.customerPrice;
+  const originalAmount = variant.customerPrice;
   return {
     type: TransactionTypes.Normal,
     identifier: variant.tTransactionID,


### PR DESCRIPTION
closes https://github.com/eshaham/israeli-bank-scrapers/issues/851

This pull request contains a small but significant change in the `src/scrapers/behatsdaa.ts` file. The `variantToTransaction` function has been modified to no longer negate the `customerPrice` when assigning it to `originalAmount`. This means that the transaction amount will now be represented as a positive value, rather than a negative one.