### PR TITLE
feat: fetch credit card line of credit utilization

### DIFF
--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -71,6 +71,11 @@ export interface ScraperOptions {
   combineInstallments?: boolean;
 
   /**
+   * if set to true, will fetch the credit utilization of the account (credit card only)
+   */
+  includeCreditUtilization?: boolean;
+
+  /**
    * additional arguments to pass to the browser instance. The list of flags can be found in
    *
    * https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,6 +1,15 @@
 
 export interface TransactionsAccount {
   accountNumber: string;
+
+  /**
+   * Relevant only for credit cards, this is the line of credit utilization, and credit limit.
+   * Only fetched if `includeCreditUtilization` is set to true in the scraper options.
+   */
+  credit?: {
+    creditUtilization: number;
+    creditLimit: number;
+  };
   balance?: number;
   txns: Transaction[];
 }


### PR DESCRIPTION
Optional feature to fetch credit card line of credit utilization and limit.
Initial support for Isracard-amex, Cal, Max.
This is a replacement PR of #795.
The main changes from #795:
1. Added Max & Cal
2. Fixed comment regarding returned data type (Thanks @esakal)
3. Added a parameter to control whether credit utilization is collected (Thanks again @esakal)

Sorry for the long delay doing this, hope this answers your concerns and we can merge :)
