### PR TITLE
refactor: update quote-props eslint rule to use consistent-as-needed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
       "ignorePattern": "^(async )?function "
     }],
     "linebreak-style": process.platform === "win32"? 0: 2,
+    "quote-props": ["error", "consistent-as-needed"],
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/ban-ts-ignore": 0,

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -5,7 +5,7 @@ const JSON_CONTENT_TYPE = 'application/json';
 
 function getJsonHeaders() {
   return {
-    Accept: JSON_CONTENT_TYPE,
+    'Accept': JSON_CONTENT_TYPE,
     'Content-Type': JSON_CONTENT_TYPE,
   };
 }

--- a/src/scrapers/behatsdaa.ts
+++ b/src/scrapers/behatsdaa.ts
@@ -100,9 +100,9 @@ class BehatsdaaScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials
     debug('Fetching data');
 
     const res = await fetchPostWithinPage<PurchaseHistoryResponse>(this.page, PURCHASE_HISTORY_URL, body, {
-      authorization: `Bearer ${token}`,
+      'authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
-      organizationid: '20',
+      'organizationid': '20',
     });
 
     debug('Data fetched');

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -105,7 +105,7 @@ function createDataFromRequest(request: Request, optionsStartDate: Date) {
 
 function createHeadersFromRequest(request: Request) {
   return {
-    mizrahixsrftoken: request.headers().mizrahixsrftoken,
+    'mizrahixsrftoken': request.headers().mizrahixsrftoken,
     'Content-Type': request.headers()['content-type'],
   };
 }


### PR DESCRIPTION
This pull request updates the quote-props eslint rule to use the consistent-as-needed option. This change ensures that object property quotes are consistent throughout the codebase.