### PR TITLE
Fix leumi.ts multiple account

### DIFF
--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -180,8 +180,8 @@ async function fetchTransactions(page: Page, startDate: Moment): Promise<Transac
   for (const accountId of accountsIds) {
     if (accountsIds.length > 1) {
       // get list of accounts and check accountId
-      await clickByXPath(page, 'xpath//*[contains(@class, "number") and contains(@class, "combo-inner")]');
-      await clickByXPath(page, `xpath//span[contains(text(), '${accountId}')]`);
+      await clickByXPath(page, 'xpath///*[contains(@class, "number") and contains(@class, "combo-inner")]');
+      await clickByXPath(page, `xpath///span[contains(text(), '${accountId}')]`);
     }
 
     accounts.push(await fetchTransactionsForAccount(page, startDate, removeSpecialCharacters(accountId)));


### PR DESCRIPTION
This PR commit a fix to Leumi scraper multiple account support. 

The fix: When switching account using the `xpath` there was a missing `/`