### PR TITLE
fix(max): allow scraping older transactions

### DIFF
--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -278,8 +278,9 @@ function prepareTransactions(txns: Transaction[], startMoment: moment.Moment, co
 async function fetchTransactions(page: Page, options: ScraperOptions) {
   const futureMonthsToScrape = options.futureMonthsToScrape ?? 1;
   const defaultStartMoment = moment().subtract(1, 'years');
+  const startMomentLimit = moment().subtract(4, 'years');
   const startDate = options.startDate || defaultStartMoment.toDate();
-  const startMoment = moment.max(defaultStartMoment, moment(startDate));
+  const startMoment = moment.max(startMomentLimit, moment(startDate));
   const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
 
   await loadCategories(page);


### PR DESCRIPTION
Max allows allows retrieving data from up to 4 years ago:
![image](https://github.com/user-attachments/assets/8285da28-0c99-43c2-8841-7541409d58ab)

Mitigates #894 for Max

### Test
Set `startDate` in `.tests-config.js` to 5 years ago and ran tests:
```
 PASS  src/scrapers/max.test.ts (76.074 s)
```
`max.csv` output file had transactions going all the way back