### PR TITLE
fix(beinleumi): allow scraping older transactions

### DIFF
--- a/src/scrapers/base-beinleumi-group.ts
+++ b/src/scrapers/base-beinleumi-group.ts
@@ -341,8 +341,9 @@ class BeinleumiGroupBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCr
 
   async fetchData() {
     const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
+    const startMomentLimit = moment({ year: 1600 });
     const startDate = this.options.startDate || defaultStartMoment.toDate();
-    const startMoment = moment.max(defaultStartMoment, moment(startDate));
+    const startMoment = moment.max(startMomentLimit, moment(startDate));
 
     await this.navigateTo(this.TRANSACTIONS_URL);
 


### PR DESCRIPTION
Beinleumi allows retrieving data from 1600 :joy:
![image](https://github.com/user-attachments/assets/58c85534-b024-4474-81c3-c1724689a935)

Any earlier than that and it fails:
![image](https://github.com/user-attachments/assets/b86fd95d-9dcd-4fd5-b7be-cf7460588449)


Mitigates https://github.com/eshaham/israeli-bank-scrapers/issues/894 for Beinleumi

### Test
Set `startDate` in `.tests-config.js` to 5 years ago and ran tests:
```
 PASS  src/scrapers/beinleumi.test.ts (35.25 s)
```
`beinleumi.csv` output file had transactions going all the way back