### PR TITLE
fix(beinleumi): support both new and old UI

### DIFF
--- a/src/scrapers/base-beinleumi-group.ts
+++ b/src/scrapers/base-beinleumi-group.ts
@@ -54,7 +54,7 @@ export function getPossibleLoginResults(): PossibleLoginResults {
   const urls: PossibleLoginResults = {};
   urls[LoginResults.Success] = [
     /fibi.*accountSummary/,  // New UI pattern
-    /FibiMenu\/Online/       // Old UI pattern
+    /FibiMenu\/Online/,       // Old UI pattern
   ];
   urls[LoginResults.InvalidPassword] = [/FibiMenu\/Marketing\/Private\/Home/];
   return urls;


### PR DESCRIPTION
This pull request includes several updates to the `src/scrapers/base-beinleumi-group.ts` file to enhance compatibility with both the new and old user interfaces of the banking website. The changes focus on updating the selectors and improving the resilience of iframe handling.

Key updates include:

### UI Compatibility Enhancements:
* Updated `getPossibleLoginResults` function to recognize patterns from both the new and old UI.
* Enhanced `waitForPostLogin` function to wait for elements specific to both UI versions.

### Iframe Handling Improvements:
* Introduced a retry mechanism in `getTransactionsFrame` to handle cases where the iframe might not be immediately available.
* Defined a constant `IFRAME_NAME` for the iframe name to avoid hardcoding it multiple times.

### Account Data Fetching:
* Modified the logic in `fetchAccounts` to handle both single and multiple account scenarios more robustly, and to use the appropriate page or iframe based on availability.