### PR TITLE
fix(beinleumi): add waits on balance and account elements

### DIFF
--- a/src/scrapers/base-beinleumi-group.ts
+++ b/src/scrapers/base-beinleumi-group.ts
@@ -51,6 +51,7 @@ export function getPossibleLoginResults(): PossibleLoginResults {
   const urls: PossibleLoginResults = {};
   urls[LoginResults.Success] = [
     /fibi.*accountSummary/, // New UI pattern
+    /Resources\/PortalNG\/shell/, // New UI pattern
     /FibiMenu\/Online/, // Old UI pattern
   ];
   urls[LoginResults.InvalidPassword] = [/FibiMenu\/Marketing\/Private\/Home/];

--- a/src/scrapers/base-beinleumi-group.ts
+++ b/src/scrapers/base-beinleumi-group.ts
@@ -283,7 +283,7 @@ async function getAccountTransactions(page: Page | Frame) {
   return txns;
 }
 
-async function getCurrentBalance(page: Page | Frame): Promise<number | undefined> {
+async function getCurrentBalance(page: Page | Frame): Promise<number> {
   // Wait for the balance element to appear and be visible
   await waitUntilElementFound(page, CURRENT_BALANCE, true, ELEMENT_RENDER_TIMEOUT_MS);
 


### PR DESCRIPTION
Added wait statement on balance and account number element getters. 
After testing in some runtime environments (Github actions) these can render slower causing "fail to find element ... " errors that are not observed on local machine runtime.
Also cleaned up wait timeout in base scrapper and unified under a single const. 