### PR TITLE
fix: add page ready state check to prevent execution context errors

### DIFF
--- a/src/helpers/elements-interactions.ts
+++ b/src/helpers/elements-interactions.ts
@@ -82,6 +82,7 @@ async function pageEvalAll<R>(
 ): Promise<R> {
   let result = defaultResult;
   try {
+    await page.waitForFunction(() => document.readyState === 'complete');
     result = await page.$$eval(selector, callback, ...args);
   } catch (e) {
     // TODO temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until they will release a new version.
@@ -102,6 +103,7 @@ async function pageEval<R>(
 ): Promise<R> {
   let result = defaultResult;
   try {
+    await pageOrFrame.waitForFunction(() => document.readyState === 'complete');
     result = await pageOrFrame.$eval(selector, callback, ...args);
   } catch (e) {
     // TODO temporary workaround to puppeteer@1.5.0 which breaks $$eval bevahvior until they will release a new version.

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -75,6 +75,14 @@ function createGeneralError(): ScraperScrapingResult {
   };
 }
 
+async function safeCleanup(cleanup: () => Promise<void>) {
+  try {
+    await cleanup();
+  } catch (e) {
+    debug(`Cleanup function failed: ${(e as Error).message}`);
+  }
+}
+
 class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends BaseScraper<TCredentials> {
   private cleanups: Array<() => Promise<void>> = [];
 
@@ -291,7 +299,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       });
     }
 
-    await Promise.all(this.cleanups.reverse().map(cleanup => cleanup()));
+    await Promise.all(this.cleanups.reverse().map(safeCleanup));
     this.cleanups = [];
   }
 

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -56,9 +56,7 @@ export class BaseScraper<TCredentials extends ScraperCredentials> implements Scr
       const success = scrapeResult && scrapeResult.success === true;
       await this.terminate(success);
     } catch (e) {
-      if (!(e as Error).message.includes('Target.closeTarget')) {
-        throw e;
-      }
+      scrapeResult = createGenericError((e as Error).message);
     }
     this.emitProgress(ScraperProgressTypes.EndScraping);
 

--- a/src/scrapers/base-scraper.ts
+++ b/src/scrapers/base-scraper.ts
@@ -56,7 +56,9 @@ export class BaseScraper<TCredentials extends ScraperCredentials> implements Scr
       const success = scrapeResult && scrapeResult.success === true;
       await this.terminate(success);
     } catch (e) {
-      scrapeResult = createGenericError((e as Error).message);
+      if (!(e as Error).message.includes('Target.closeTarget')) {
+        throw e;
+      }
     }
     this.emitProgress(ScraperProgressTypes.EndScraping);
 


### PR DESCRIPTION
- Fix "Protocol error (Target.closeTarget): No target with given id found" caused by cleanup functions being called after page closure
- Fix "Navigation timeout of 30000 ms exceeded" caused by executing code before page is ready
- Add waitForFunction check to ensure document.readyState === 'complete' before $eval operations in pageEval function

Resolves #952, #962