### PR TITLE
hang the process to avoid application not respecting the login click

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -178,7 +178,7 @@ async function getLoginFrame(page: Page) {
   let frame: Frame | null = null;
   debug('wait until login frame found');
   await waitUntil(
-    () => {      
+    () => {
       frame = page.frames().find(f => f.url().includes('connect')) || null;
       return Promise.resolve(!!frame);
     },


### PR DESCRIPTION
It looks like CAL added a temporary overlay that causes the login button click event to be ignored even when the button is already rendered.