### PR TITLE
fix(discount): fix login and scraping

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -64,6 +64,7 @@ async function fetchAccountData(page: Page, options: ScraperOptions): Promise<Sc
   const apiSiteUrl = `${BASE_URL}/Titan/gatewayAPI`;
 
   const accountDataUrl = `${apiSiteUrl}/userAccountsData`;
+  await waitForNavigation(page);
   const accountInfo = await fetchGetWithinPage<ScrapedAccountData>(page, accountDataUrl);
 
   if (!accountInfo) {
@@ -124,7 +125,10 @@ async function navigateOrErrorLabel(page: Page) {
 
 function getPossibleLoginResults(): PossibleLoginResults {
   const urls: PossibleLoginResults = {};
-  urls[LoginResults.Success] = [`${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`];
+  urls[LoginResults.Success] = [
+    `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`, // Old url
+    `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`, // New url
+  ];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;


### PR DESCRIPTION
The url of discont was changed from apollo/retail/#/MY_ACCOUNT_HOMEPAGE to apollo/retail2/#/MY_ACCOUNT_HOMEPAGE.
In addition, added 
await waitForNavigation(page);
otherwise getting execution context destroyed

Resolves #971