### PR TITLE
fix(discount): add additional success URL for login results

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -124,7 +124,10 @@ async function navigateOrErrorLabel(page: Page) {
 
 function getPossibleLoginResults(): PossibleLoginResults {
   const urls: PossibleLoginResults = {};
-  urls[LoginResults.Success] = [`${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`, `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`];
+  urls[LoginResults.Success] = [
+    `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`,
+    `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`,
+  ];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;


### PR DESCRIPTION
closes #971 

i've investigated the issue and saw the login of discount takes you to a different URL. i don't know if this is across the board or A/B testing so i opt to add additional login success page.

tested locally