### PR TITLE
fix(isracard and amex) scrape fixed

### DIFF
--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -20,6 +20,7 @@ import { BaseScraperWithBrowser } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
 import { interceptionPriorities, maskHeadlessUserAgent } from '../helpers/browser';
+import { clickButton, waitUntilElementFound } from '../helpers/elements-interactions';
 
 const COUNTRY_CODE = '212';
 const ID_TYPE = '1';
@@ -406,6 +407,12 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
     await this.navigateTo(`${this.baseUrl}/personalarea/Login`);
 
     this.emitProgress(ScraperProgressTypes.LoggingIn);
+
+    await waitUntilElementFound(this.page, '#flip', true);
+    debug('click on the "Enter with password" button');
+    await clickButton(this.page, '#flip');
+    debug('Wait for the panel to visually flip');
+    await waitUntilElementFound(this.page, '#otpLoginPwd', true);
 
     const validateUrl = `${this.servicesUrl}?reqName=ValidateIdData`;
     const validateRequest = {


### PR DESCRIPTION
This commit resolves #997 

Hey everyone, first time pull request here, please help me verify I'm up to your spec.
I've tested this fix with my personal account, failed before my change, works well after my change.
I'll need help testing amex with this fix

I made a change that impacts both Amex and Isracard, but I could verify only isracard with my personal account. I want to avoid fragmentation of the inheritance of the base class. 
I verified visually that the amex client uses the same identifiers for everything so this *should* work.