### PR TITLE
fix(mizrahi): scrape all pending transactions, skip pending with no date

### DIFF
--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -134,21 +134,23 @@ async function extractPendingTransactions(page: Frame): Promise<Transaction[]> {
   });
 
   return pendingTxn
-    .map(txn => {
-      const date = moment(txn[0], 'DD/MM/YY').toISOString();
-      const amount = parseInt(txn[3], 10);
-      return {
-        type: TransactionTypes.Normal,
-        date,
-        processedDate: date,
-        originalAmount: amount,
-        originalCurrency: SHEKEL_CURRENCY,
-        chargedAmount: amount,
-        description: txn[1],
-        status: TransactionStatuses.Pending,
-      };
-    })
-    .filter(txn => txn.date);
+    .map(([dateStr, description, incomeAmountStr, amountStr]) => ({
+      date: moment(dateStr, 'DD/MM/YY').toISOString(),
+      amount: parseInt(amountStr, 10),
+      description,
+      incomeAmountStr, // TODO: handle incomeAmountStr once we know the sign of it
+    }))
+    .filter(txn => txn.date)
+    .map(({ date, description, amount }) => ({
+      type: TransactionTypes.Normal,
+      date,
+      processedDate: date,
+      originalAmount: amount,
+      originalCurrency: SHEKEL_CURRENCY,
+      chargedAmount: amount,
+      description,
+      status: TransactionStatuses.Pending,
+    }));
 }
 
 async function postLogin(page: Page) {


### PR DESCRIPTION
* Expanded row selection to include both `tr.rgRow` and `tr.rgAltRow`, ensuring all relevant transaction rows are processed.
* Refactored the mapping logic to destructure transaction fields directly and filter out invalid dates.
* Added a TODO for handling `incomeAmountStr`, indicating future work to correctly determine transaction sign.