### PR TITLE
fix(hapoalim): only scrape account if it is an active account

### DIFF
--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -197,7 +197,11 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
   debug('fetching accounts data');
   const accountsInfo = (await fetchGetWithinPage<FetchedAccountData>(page, accountDataUrl)) || [];
   const openAccountsInfo = accountsInfo.filter(account => account.accountClosingReasonCode === 0);
-  debug('got %d open accounts from %d total accounts, fetching txns and balance', openAccountsInfo.length, accountsInfo.length);
+  debug(
+    'got %d open accounts from %d total accounts, fetching txns and balance',
+    openAccountsInfo.length,
+    accountsInfo.length,
+  );
 
   const defaultStartMoment = moment().subtract(1, 'years').add(1, 'day');
   const startDate = options.startDate || defaultStartMoment.toDate();


### PR DESCRIPTION
In a situation where you have 2 accounts, one active and one inactive the current logic will still try and get the inactive accounts transactions causing the scrape to fail.
This change will call `getAccountTransactions` on active accounts

Resolves issue #1021 