### PR TITLE
feat(hapoalim): Add Forex, Savings, & Investment Accounts

### DIFF
--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -123,7 +123,7 @@ interface InvestmentSecurityBalance {
   BaseRate?: number;
   LastRate?: number;
   BaseRateChangePercentage?: number;
-  OnlineNV?: number;
+  OnlineNV: number;
   OnlineVL: number;
   OnlineNisVL?: number;
   ProfitLoss?: number;
@@ -531,6 +531,7 @@ async function getInvestmentAccounts(
         securities.push({
           name: meta?.EngName || '',
           symbol: meta?.EngSymbol || '',
+          volume: securityBalance.OnlineNV,
           value: securityBalance.OnlineVL,
           currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
           changePercentage: securityBalance.BaseRateChangePercentage,
@@ -541,8 +542,7 @@ async function getInvestmentAccounts(
       debug('  - Balance: %s %s, Securities: %d', balance, currency, securities.length);
 
       if (balance !== 0 || securities.length > 0) {
-        const investmentAccountNumber = `${account.bankNumber}-${account.accountNumber}-investment`;
-
+        const investmentAccountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}-investment`;
         accounts.push({
           accountNumber: investmentAccountNumber,
           balance,

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -348,24 +348,19 @@ async function getSavingsAccounts(baseUrl: string, page: Page, accountNumber: st
   const accounts: TransactionsAccount[] = [];
 
   for (const wrapper of savingsData.depositsWrapperData) {
-    const totalBalance = wrapper.revaluatedAmount || wrapper.amount;
+    // Create a separate account for each individual deposit
+    for (const deposit of wrapper.data) {
+      const balance = deposit.revaluedTotalAmount || deposit.principalAmount;
+      const savingsAccountNumber = `${accountNumber}-${deposit.depositSerialId}`;
 
-    // For savings accounts, we create one account per wrapper with the total balance
-    // Individual deposits don't have transaction history, just balance snapshots
-    const savingsAccountNumber = `${accountNumber}-SAVINGS`;
-
-    // Check if we already added this account (in case of multiple deposits)
-    const existingAccount = accounts.find(acc => acc.accountNumber === savingsAccountNumber);
-
-    if (existingAccount) {
-      // Add to existing balance
-      existingAccount.balance = (existingAccount.balance || 0) + totalBalance;
-    } else {
       accounts.push({
         accountNumber: savingsAccountNumber,
-        balance: totalBalance,
+        savingsAccount: true,
+        balance,
         txns: [], // Savings accounts typically don't have transaction history in the same way
       });
+
+      debug('Added savings account %s with balance %s', savingsAccountNumber, balance);
     }
   }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -316,6 +316,7 @@ async function getForexAccounts(
           accounts.push({
             accountNumber: forexAccountNumber,
             balance,
+            currency: currencySwiftCode,
             txns,
           });
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,7 +1,8 @@
 export interface TransactionsAccount {
   accountNumber: string;
-  savingsAccount?: boolean;
   balance?: number;
+  currency?: string;
+  savingsAccount?: boolean;
   txns: Transaction[];
 }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,6 +4,7 @@ export interface TransactionsAccount {
   currency?: string;
   savingsAccount?: boolean;
   txns: Transaction[];
+  securities?: Security[];
 }
 
 export enum TransactionTypes {
@@ -51,4 +52,13 @@ export interface Transaction {
   status: TransactionStatuses;
   installments?: TransactionInstallments;
   category?: string;
+}
+
+export interface Security {
+  name?: string;
+  symbol: string;
+  value: number;
+  currency?: string;
+  changePercentage?: number;
+  profitLoss?: number;
 }

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -57,6 +57,7 @@ export interface Transaction {
 export interface Security {
   name?: string;
   symbol: string;
+  volume: number;
   value: number;
   currency?: string;
   changePercentage?: number;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,5 +1,6 @@
 export interface TransactionsAccount {
   accountNumber: string;
+  savingsAccount?: boolean;
   balance?: number;
   txns: Transaction[];
 }


### PR DESCRIPTION
- Adds support for scraping transaction history from Bank Hapoalim foreign currency accounts
- Adds support for scraping Bank Hapoalim savings account balances
- Adds support for scraping Bank Hapoalim investment account holdings

Tested locally. New accounts in output look like:
```
    {
      "accountNumber": "12-XXX-XXXXXX-USD",
      "balance": 1000.00,
      "currency": "USD",
      "txns": [
        {
          "type": "normal",
          "identifier": 10017,
          "date": "2025-10-02T21:00:00.000Z",
          "processedDate": "2025-10-15T21:00:00.000Z",
          "originalAmount": 1000.00,
          "originalCurrency": "USD",
          "chargedAmount": 1000.00,
          "description": "העברה מחו\"ל",
          "status": "completed",
          "memo": "Bob Smith"
        }
    },
    {
      "accountNumber": "12-XXX-XXXXXX-3382501",
      "savingsAccount": true,
      "balance": 10000.00,
      "txns": []
    },
    {
      "accountNumber": "12-XXX-XXXXXX-investment",
      "balance": 149.98,
      "currency": "ILS",
      "savingsAccount": true,
      "txns": [],
      "securities": [
        {
          "name": "POALIM",
          "symbol": "POLI",
          "volume": 2,
          "value": 149.98,
          "currency": "ILS",
          "changePercentage": -1.04,
          "profitLoss": -1.58
        }
      ]
    }
```
