### PR TITLE
feat(hapoalim): add forex, savings, & investment accounts

### DIFF
--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -123,7 +123,7 @@ interface InvestmentSecurityBalance {
   BaseRate?: number;
   LastRate?: number;
   BaseRateChangePercentage?: number;
-  OnlineNV?: number;
+  OnlineNV: number;
   OnlineVL: number;
   OnlineNisVL?: number;
   ProfitLoss?: number;
@@ -531,6 +531,7 @@ async function getInvestmentAccounts(
         securities.push({
           name: meta?.EngName || '',
           symbol: meta?.EngSymbol || '',
+          volume: securityBalance.OnlineNV,
           value: securityBalance.OnlineVL,
           currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
           changePercentage: securityBalance.BaseRateChangePercentage,
@@ -541,8 +542,7 @@ async function getInvestmentAccounts(
       debug('  - Balance: %s %s, Securities: %d', balance, currency, securities.length);
 
       if (balance !== 0 || securities.length > 0) {
-        const investmentAccountNumber = `${account.bankNumber}-${account.accountNumber}-investment`;
-
+        const investmentAccountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}-investment`;
         accounts.push({
           accountNumber: investmentAccountNumber,
           balance,

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -348,24 +348,19 @@ async function getSavingsAccounts(baseUrl: string, page: Page, accountNumber: st
   const accounts: TransactionsAccount[] = [];
 
   for (const wrapper of savingsData.depositsWrapperData) {
-    const totalBalance = wrapper.revaluatedAmount || wrapper.amount;
+    // Create a separate account for each individual deposit
+    for (const deposit of wrapper.data) {
+      const balance = deposit.revaluedTotalAmount || deposit.principalAmount;
+      const savingsAccountNumber = `${accountNumber}-${deposit.depositSerialId}`;
 
-    // For savings accounts, we create one account per wrapper with the total balance
-    // Individual deposits don't have transaction history, just balance snapshots
-    const savingsAccountNumber = `${accountNumber}-SAVINGS`;
-
-    // Check if we already added this account (in case of multiple deposits)
-    const existingAccount = accounts.find(acc => acc.accountNumber === savingsAccountNumber);
-
-    if (existingAccount) {
-      // Add to existing balance
-      existingAccount.balance = (existingAccount.balance || 0) + totalBalance;
-    } else {
       accounts.push({
         accountNumber: savingsAccountNumber,
-        balance: totalBalance,
+        savingsAccount: true,
+        balance,
         txns: [], // Savings accounts typically don't have transaction history in the same way
       });
+
+      debug('Added savings account %s with balance %s', savingsAccountNumber, balance);
     }
   }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -316,6 +316,7 @@ async function getForexAccounts(
           accounts.push({
             accountNumber: forexAccountNumber,
             balance,
+            currency: currencySwiftCode,
             txns,
           });
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -122,11 +122,11 @@ interface InvestmentSecurityBalance {
   EquityNumber: string;
   BaseRate?: number;
   LastRate?: number;
-  BaseRateChangePercentage?: number;
+  AveragePriceProfitLossPercentage?: number;
   OnlineNV: number;
   OnlineVL: number;
   OnlineNisVL?: number;
-  ProfitLoss?: number;
+  AveragePriceProfitLoss?: number;
   CurrencyCode?: string;
 }
 
@@ -536,8 +536,9 @@ async function getInvestmentAccounts(
           volume: securityBalance.OnlineNV,
           value: securityBalance.OnlineVL,
           currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
-          changePercentage: securityBalance.BaseRateChangePercentage,
-          profitLoss: securityBalance.ProfitLoss,
+          // Use AveragePrice to get overall profit/loss data for the security
+          changePercentage: securityBalance.AveragePriceProfitLossPercentage,
+          profitLoss: Math.round((securityBalance.AveragePriceProfitLoss || 0) * 100) / 100, // Round to two decimal places
         });
       }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -330,8 +330,7 @@ async function getForexAccounts(
 
   const currency = { code: 19, swift: SHEKEL_CURRENCY };
   try {
-    const detailedAccountTypeCode = 142; // For foreign currency accounts
-    const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&currencyCodeList=${currency.code}&detailedAccountTypeCodeList=${detailedAccountTypeCode}&view=details&lang=he`;
+    const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&lang=he`;
     debug('Trying forex %s', forexUrl);
 
     const forexData = await fetchGetWithinPage<ForexAccountData>(page, forexUrl, true); // ignoreErrors = true
@@ -343,14 +342,8 @@ async function getForexAccounts(
         const currencySwiftCode = currencyData.currencySwiftCode || currency.swift;
         const transactionCount = currencyData.transactions?.length || 0;
 
-        // Get balance from the most recent transaction's currentBalance field
-        // If no transactions, fall back to currencyData.currentBalance
-        let balance = currencyData.currentBalance;
-        if (transactionCount > 0 && currencyData.transactions) {
-          balance = currencyData.transactions[0].currentBalance;
-          debug('  - Using balance from most recent transaction: %s', balance);
-        }
-
+        // Get balance from currencyData.currentBalance
+        const balance = currencyData.currentBalance;
         debug('  - Currency: %s, Balance: %s, Transactions: %d', currencySwiftCode, balance, transactionCount);
 
         // Log transaction dates for debugging
@@ -381,7 +374,6 @@ async function getForexAccounts(
     }
   } catch (error) {
     debug('  - Error fetching forex: %s', error);
-    // Continue trying other currencies
   }
 
   debug('Returning %d forex accounts', accounts.length);

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -125,11 +125,11 @@ interface InvestmentSecurityBalance {
   EquityNumber: string;
   BaseRate?: number;
   LastRate?: number;
-  BaseRateChangePercentage?: number;
+  AveragePriceProfitLossPercentage?: number;
   OnlineNV: number;
   OnlineVL: number;
   OnlineNisVL?: number;
-  ProfitLoss?: number;
+  AveragePriceProfitLoss?: number;
   CurrencyCode?: string;
 }
 
@@ -548,8 +548,9 @@ async function getInvestmentAccounts(
           volume: securityBalance.OnlineNV,
           value: securityBalance.OnlineVL,
           currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
-          changePercentage: securityBalance.BaseRateChangePercentage,
-          profitLoss: securityBalance.ProfitLoss,
+          // Use AveragePrice to get overall profit/loss data for the security
+          changePercentage: securityBalance.AveragePriceProfitLossPercentage,
+          profitLoss: Math.round((securityBalance.AveragePriceProfitLoss || 0) * 100) / 100, // Round to two decimal places
         });
       }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -1,19 +1,12 @@
 import moment from 'moment';
 import { type Page } from 'puppeteer';
 import { randomUUID } from 'crypto';
-import { v4 as uuid4 } from 'uuid';
 import { SHEKEL_CURRENCY } from '../constants';
 import { getDebug } from '../helpers/debug';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { waitForRedirect } from '../helpers/navigation';
 import { waitUntil } from '../helpers/waiting';
-import {
-  type Transaction,
-  TransactionStatuses,
-  TransactionTypes,
-  type TransactionsAccount,
-  type Security,
-} from '../transactions';
+import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount, type Security } from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
 import { type ScraperOptions } from './interface';
 import { getRawTransaction } from '../helpers/transactions';
@@ -229,8 +222,8 @@ function convertForexTransactions(txns: ForexTransaction[], currency: string): T
     const result: Transaction = {
       type: TransactionTypes.Normal,
       identifier: txn.referenceNumber || txn.recordSerialNumber,
-      date: moment(valueDateStr, DATE_FORMAT).toISOString(),
-      processedDate: moment(dateStr, DATE_FORMAT).toISOString(),
+      date: moment(dateStr, DATE_FORMAT).toISOString(),
+      processedDate: moment(valueDateStr, DATE_FORMAT).toISOString(),
       originalAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
       originalCurrency: currency,
       chargedAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
@@ -497,7 +490,7 @@ async function getInvestmentAccounts(
     const XSRFCookie = cookies.find(cookie => cookie.name === 'XSRF-TOKEN');
 
     // Use captured session or fallback to generated ones
-    const sessionId = capturedSession || uuid4();
+    const sessionId = capturedSession || randomUUID();
     const csession = capturedCsession || Math.random().toString();
 
     const headers: Record<string, any> = {
@@ -510,8 +503,6 @@ async function getInvestmentAccounts(
       headers['X-XSRF-TOKEN'] = XSRFCookie.value;
       debug('  - Using XSRF token: %s', XSRFCookie.value.substring(0, 10) + '...');
     }
-
-    debug('  - Request headers: csession=%s, session=%s', csession, sessionId);
 
     const investmentData = await fetchPostWithinPage<InvestmentAccountData>(page, investmentUrl, {}, headers);
 
@@ -635,32 +626,20 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
     debug('getting information for account %s', account.accountNumber);
     const accountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}`;
 
-    let balance;
-    const isActiveAccount = account.accountClosingReasonCode === 0;
-    if (isActiveAccount) {
-      balance = await getAccountBalance(apiSiteUrl, page, accountNumber);
-    } else {
-      debug('Skipping balance for a closed account, balance will be undefined');
-    }
+    // Fetch regular chequing accounts for this account number
+    const balance = await getAccountBalance(apiSiteUrl, page, accountNumber);
+    const txns = await getAccountTransactions(
+      baseUrl,
+      apiSiteUrl,
+      page,
+      accountNumber,
+      startDateStr,
+      endDateStr,
+      additionalTransactionInformation,
+      options,
+    );
 
-    let txns: Transaction[] = [];
-    try {
-      txns = await getAccountTransactions(
-        baseUrl,
-        apiSiteUrl,
-        page,
-        accountNumber,
-        startDateStr,
-        endDateStr,
-        additionalTransactionInformation,
-        options,
-      );
-    } catch (error) {
-      debug('Error fetching transactions for %s (possibly closed account): %s', accountNumber, error);
-      // Continue with empty transactions
-    }
-
-    // Add regular checking account
+    // Add regular chequing account
     accounts.push({
       accountNumber,
       balance,

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -65,6 +65,54 @@ type BalanceAndCreditLimit = {
   withdrawalBalance: number;
 };
 
+interface ForexTransaction {
+  executingDate: number;
+  valueDate: number;
+  activityDescription: string;
+  eventAmount: number;
+  currentBalance: number;
+  referenceNumber?: number;
+  eventDetails?: string;
+  eventActivityTypeCode: number;
+  currencySwiftCode: string;
+  recordSerialNumber?: number;
+}
+
+interface ForexCurrencyData {
+  currencyCode: number;
+  currencySwiftCode: string;
+  currencySwiftDescription: string;
+  currentBalance: number;
+  transactions: ForexTransaction[];
+  detailedAccountTypeCode: number;
+}
+
+interface ForexAccountData {
+  balancesAndLimitsDataList: ForexCurrencyData[];
+}
+
+interface SavingsDeposit {
+  principalAmount: number;
+  revaluedTotalAmount: number;
+  depositSerialId: number;
+  productFreeText?: string;
+  shortProductName?: string;
+  formattedAgreementOpeningDate?: string;
+  formattedEndExitDate?: string;
+  nominalInterest?: number;
+  detailedAccountTypeCode: number;
+}
+
+interface SavingsWrapper {
+  data: SavingsDeposit[];
+  amount: number;
+  revaluatedAmount: number;
+}
+
+interface SavingsAccountData {
+  depositsWrapperData: SavingsWrapper[];
+}
+
 function convertTransactions(txns: ScrapedTransaction[], options?: ScraperOptions): Transaction[] {
   return txns.map(txn => {
     const isOutbound = txn.eventActivityTypeCode === 2;
@@ -110,6 +158,34 @@ function convertTransactions(txns: ScrapedTransaction[], options?: ScraperOption
     if (options?.includeRawTransaction) {
       result.rawTransaction = getRawTransaction(txn);
     }
+
+    return result;
+  });
+}
+
+function convertForexTransactions(txns: ForexTransaction[], currency: string): Transaction[] {
+  return txns.map(txn => {
+    const isOutbound = txn.eventActivityTypeCode === 2;
+    const dateStr = txn.executingDate.toString(); // Date transaction was executed
+    const valueDateStr = txn.valueDate.toString(); // Date value was actually added to account
+
+    let memo = '';
+    if (txn.eventDetails) {
+      memo = txn.eventDetails;
+    }
+
+    const result: Transaction = {
+      type: TransactionTypes.Normal,
+      identifier: txn.referenceNumber || txn.recordSerialNumber,
+      date: moment(valueDateStr, DATE_FORMAT).toISOString(),
+      processedDate: moment(dateStr, DATE_FORMAT).toISOString(),
+      originalAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
+      originalCurrency: currency,
+      chargedAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
+      description: txn.activityDescription || '',
+      status: TransactionStatuses.Completed,
+      memo,
+    };
 
     return result;
   });
@@ -200,6 +276,113 @@ async function getAccountBalance(apiSiteUrl: string, page: Page, accountNumber: 
   return balanceAndCreditLimit?.currentBalance;
 }
 
+async function getForexAccounts(
+  baseUrl: string,
+  page: Page,
+  accountNumber: string,
+  startDate: string,
+  endDate: string,
+): Promise<TransactionsAccount[]> {
+  debug('========== FETCHING FOREX ACCOUNTS ==========');
+  debug('Account: %s, Date range: %s to %s', accountNumber, startDate, endDate);
+
+  const accounts: TransactionsAccount[] = [];
+
+  const currency = { code: 19, swift: 'ILS' };
+  try {
+    const detailedAccountTypeCode = 142; // For foreign currency accounts
+    const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&currencyCodeList=${currency.code}&detailedAccountTypeCodeList=${detailedAccountTypeCode}&view=details&lang=he`;
+    debug('Trying forex %s', forexUrl);
+
+    const forexData = await fetchGetWithinPage<ForexAccountData>(page, forexUrl, true); // ignoreErrors = true
+
+    if (forexData && forexData.balancesAndLimitsDataList && forexData.balancesAndLimitsDataList.length > 0) {
+      debug('✓ Found forex data');
+
+      for (const currencyData of forexData.balancesAndLimitsDataList) {
+        const currencySwiftCode = currencyData.currencySwiftCode || currency.swift;
+        const transactionCount = currencyData.transactions?.length || 0;
+
+        // Get balance from the most recent transaction's currentBalance field
+        // If no transactions, fall back to currencyData.currentBalance
+        let balance = currencyData.currentBalance;
+        if (transactionCount > 0 && currencyData.transactions) {
+          balance = currencyData.transactions[0].currentBalance;
+          debug('  - Using balance from most recent transaction: %s', balance);
+        }
+
+        debug('  - Currency: %s, Balance: %s, Transactions: %d', currencySwiftCode, balance, transactionCount);
+
+        // Log transaction dates for debugging
+        if (transactionCount > 0) {
+          const txnDates = currencyData.transactions?.map(t => t.executingDate).join(', ') || '';
+          debug('    Transaction dates: %s', txnDates);
+        }
+
+        // Only add if there's actually a balance or transactions
+        if (balance !== 0 || transactionCount > 0) {
+          const txns = convertForexTransactions(currencyData.transactions || [], currencySwiftCode);
+          const forexAccountNumber = `${accountNumber}-${currencySwiftCode}`;
+
+          accounts.push({
+            accountNumber: forexAccountNumber,
+            balance,
+            txns,
+          });
+
+          debug('  ✓ Added forex account: %s with %d transactions', forexAccountNumber, txns.length);
+        } else {
+          debug('  - Skipping %s (zero balance and no transactions)', currencySwiftCode);
+        }
+      }
+    } else {
+      debug('  - No forex data found');
+    }
+  } catch (error) {
+    debug('  - Error fetching forex: %s', error);
+    // Continue trying other currencies
+  }
+
+  debug('Returning %d forex accounts', accounts.length);
+  return accounts;
+}
+
+async function getSavingsAccounts(baseUrl: string, page: Page, accountNumber: string): Promise<TransactionsAccount[]> {
+  const savingsUrl = `${baseUrl}/ServerServices/deposits-and-savings/deposits?accountId=${accountNumber}&view=details&lang=he`;
+  const savingsData = await fetchGetWithinPage<SavingsAccountData>(page, savingsUrl);
+
+  if (!savingsData || !savingsData.depositsWrapperData || savingsData.depositsWrapperData.length === 0) {
+    debug('No savings accounts found for account %s', accountNumber);
+    return [];
+  }
+
+  const accounts: TransactionsAccount[] = [];
+
+  for (const wrapper of savingsData.depositsWrapperData) {
+    const totalBalance = wrapper.revaluatedAmount || wrapper.amount;
+
+    // For savings accounts, we create one account per wrapper with the total balance
+    // Individual deposits don't have transaction history, just balance snapshots
+    const savingsAccountNumber = `${accountNumber}-SAVINGS`;
+
+    // Check if we already added this account (in case of multiple deposits)
+    const existingAccount = accounts.find(acc => acc.accountNumber === savingsAccountNumber);
+
+    if (existingAccount) {
+      // Add to existing balance
+      existingAccount.balance = (existingAccount.balance || 0) + totalBalance;
+    } else {
+      accounts.push({
+        accountNumber: savingsAccountNumber,
+        balance: totalBalance,
+        txns: [], // Savings accounts typically don't have transaction history in the same way
+      });
+    }
+  }
+
+  return accounts;
+}
+
 async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOptions) {
   const restContext = await getRestContext(page);
   const apiSiteUrl = `${baseUrl}/${restContext}`;
@@ -240,11 +423,30 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
       options,
     );
 
+    // Add regular checking account
     accounts.push({
       accountNumber,
       balance,
       txns,
     });
+
+    // Fetch forex accounts for this account number
+    try {
+      const forexAccounts = await getForexAccounts(baseUrl, page, accountNumber, startDateStr, endDateStr);
+      accounts.push(...forexAccounts);
+      debug('Added %d forex accounts to results', forexAccounts.length);
+    } catch (error) {
+      debug('Error fetching forex accounts for %s: %s', accountNumber, error);
+    }
+
+    // Fetch savings accounts for this account number
+    try {
+      const savingsAccounts = await getSavingsAccounts(baseUrl, page, accountNumber);
+      accounts.push(...savingsAccounts);
+      debug('Added %d savings accounts to results', savingsAccounts.length);
+    } catch (error) {
+      debug('Error fetching savings accounts for %s: %s', accountNumber, error);
+    }
   }
 
   const accountData = {

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -1,11 +1,19 @@
 import moment from 'moment';
 import { type Page } from 'puppeteer';
 import { randomUUID } from 'crypto';
+import { v4 as uuid4 } from 'uuid';
+import { SHEKEL_CURRENCY } from '../constants';
 import { getDebug } from '../helpers/debug';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { waitForRedirect } from '../helpers/navigation';
 import { waitUntil } from '../helpers/waiting';
-import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
+import {
+  type Transaction,
+  TransactionStatuses,
+  TransactionTypes,
+  type TransactionsAccount,
+  type Security,
+} from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
 import { type ScraperOptions } from './interface';
 import { getRawTransaction } from '../helpers/transactions';
@@ -113,6 +121,50 @@ interface SavingsAccountData {
   depositsWrapperData: SavingsWrapper[];
 }
 
+interface InvestmentSecurityBalance {
+  EquityNumber: string;
+  BaseRate?: number;
+  LastRate?: number;
+  BaseRateChangePercentage?: number;
+  OnlineNV?: number;
+  OnlineVL: number;
+  OnlineNisVL?: number;
+  ProfitLoss?: number;
+  CurrencyCode?: string;
+}
+
+interface InvestmentSecurityMeta {
+  '-Key': string;
+  EngName?: string;
+  EngSymbol?: string;
+  HebName?: string;
+  HebSymbol?: string;
+  Symbol?: string;
+  ItemType?: string;
+  StockType?: string;
+  IsForeign?: boolean;
+  CurrencyCode?: string;
+  Exchange?: string;
+  EquityType?: number;
+  EquitySubType?: number;
+}
+
+interface InvestmentAccountData {
+  View?: {
+    Account?: {
+      OnlineValue?: number;
+      OnlineCash?: number;
+      CurrencyCode?: string;
+      AccountPosition?: {
+        Balance?: InvestmentSecurityBalance[];
+      };
+    };
+    Meta?: {
+      Security?: InvestmentSecurityMeta[];
+    };
+  };
+}
+
 function convertTransactions(txns: ScrapedTransaction[], options?: ScraperOptions): Transaction[] {
   return txns.map(txn => {
     const isOutbound = txn.eventActivityTypeCode === 2;
@@ -148,7 +200,7 @@ function convertTransactions(txns: ScrapedTransaction[], options?: ScraperOption
       date: moment(txn.eventDate, DATE_FORMAT).toISOString(),
       processedDate: moment(txn.valueDate, DATE_FORMAT).toISOString(),
       originalAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
-      originalCurrency: 'ILS',
+      originalCurrency: SHEKEL_CURRENCY,
       chargedAmount: isOutbound ? -txn.eventAmount : txn.eventAmount,
       description: txn.activityDescription || '',
       status: txn.serialNumber === 0 ? TransactionStatuses.Pending : TransactionStatuses.Completed,
@@ -288,7 +340,7 @@ async function getForexAccounts(
 
   const accounts: TransactionsAccount[] = [];
 
-  const currency = { code: 19, swift: 'ILS' };
+  const currency = { code: 19, swift: SHEKEL_CURRENCY };
   try {
     const detailedAccountTypeCode = 142; // For foreign currency accounts
     const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&currencyCodeList=${currency.code}&detailedAccountTypeCodeList=${detailedAccountTypeCode}&view=details&lang=he`;
@@ -379,6 +431,167 @@ async function getSavingsAccounts(baseUrl: string, page: Page, accountNumber: st
   return accounts;
 }
 
+async function getInvestmentAccounts(
+  baseUrl: string,
+  page: Page,
+  account: { bankNumber: string; branchNumber: string; accountNumber: string },
+): Promise<TransactionsAccount[]> {
+  debug('========== FETCHING INVESTMENT ACCOUNTS ==========');
+  const accounts: TransactionsAccount[] = [];
+  const accountNumber = `${account.branchNumber}-${account.accountNumber}`; // Don't include bankNumber here because investment API doesn't use it
+
+  // Set up request interception to capture session headers
+  let capturedSession: string | null = null;
+  let capturedCsession: string | null = null;
+
+  const requestHandler = (request: any) => {
+    try {
+      const headers = request.headers();
+      if (headers.session && !capturedSession) {
+        capturedSession = headers.session;
+        debug('  - Captured session from network request');
+      }
+      if (headers.csession && !capturedCsession) {
+        capturedCsession = headers.csession;
+        debug('  - Captured csession from network request');
+      }
+      request.continue();
+    } catch (e) {
+      debug('  - Error in request handler: %s', e);
+      // Try to continue anyway
+      try {
+        request.continue();
+      } catch (continueError) {
+        // Ignore if already handled
+      }
+    }
+  };
+
+  try {
+    // Navigate to mytrade section to establish session
+    const mytradeUrl = `${baseUrl}/mytrade/app`;
+    debug('Navigating to mytrade section: %s', mytradeUrl);
+
+    await page.setRequestInterception(true);
+    page.on('request', requestHandler);
+
+    await page.goto(mytradeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+    // Wait longer for the page to fully load and establish session
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // Now turn off request interception before we make API calls
+    page.off('request', requestHandler);
+    await page.setRequestInterception(false);
+
+    debug('Mytrade page loaded, session established');
+
+    const fields =
+      'EngName,EngSymbol,HebName,HebSymbol,Symbol,ExpirationDate,ItemType,StockType,IsEtf,IsForeign,CurrencyCode,Exchange,CreationEquityNum,EquityType,ContractType,AllowedOrderDirection,EquitySubType';
+    const investmentUrl = `${baseUrl}/ServerServices/mytrade/api/v2/json2/account/view?account=${accountNumber}&fields=${fields}`;
+    debug('Trying investment account URL: %s', investmentUrl);
+
+    // Get XSRF token and session data from cookies
+    const cookies = await page.cookies();
+    const XSRFCookie = cookies.find(cookie => cookie.name === 'XSRF-TOKEN');
+
+    // Use captured session or fallback to generated ones
+    const sessionId = capturedSession || uuid4();
+    const csession = capturedCsession || Math.random().toString();
+
+    const headers: Record<string, any> = {
+      'Content-Type': 'application/json; charset=utf-8',
+      csession,
+      session: sessionId,
+      Referer: mytradeUrl,
+    };
+    if (XSRFCookie != null) {
+      headers['X-XSRF-TOKEN'] = XSRFCookie.value;
+      debug('  - Using XSRF token: %s', XSRFCookie.value.substring(0, 10) + '...');
+    }
+
+    debug('  - Request headers: csession=%s, session=%s', csession, sessionId);
+
+    const investmentData = await fetchPostWithinPage<InvestmentAccountData>(page, investmentUrl, {}, headers);
+
+    debug('  - Response received: %s', investmentData ? 'YES' : 'NO');
+    if (investmentData) {
+      debug('  - Response has View: %s', investmentData.View ? 'YES' : 'NO');
+      debug('  - Response has View.Account: %s', investmentData.View?.Account ? 'YES' : 'NO');
+    }
+
+    if (investmentData?.View?.Account) {
+      debug('✓ Found investment account data');
+
+      const accountData = investmentData.View.Account;
+      const balance = accountData.OnlineValue || 0;
+      const currency = accountData.CurrencyCode || SHEKEL_CURRENCY;
+
+      // Get securities from the balance array
+      const securities: Security[] = [];
+      const balances = accountData.AccountPosition?.Balance || [];
+      const metaSecurities = investmentData.View.Meta?.Security || [];
+
+      // Create a map of security metadata for easy lookup
+      const metaMap = new Map<string, InvestmentSecurityMeta>();
+      for (const meta of metaSecurities) {
+        metaMap.set(meta['-Key'], meta);
+      }
+
+      for (const securityBalance of balances) {
+        const meta = metaMap.get(securityBalance.EquityNumber);
+
+        securities.push({
+          name: meta?.EngName || '',
+          symbol: meta?.EngSymbol || '',
+          value: securityBalance.OnlineVL,
+          currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
+          changePercentage: securityBalance.BaseRateChangePercentage,
+          profitLoss: securityBalance.ProfitLoss,
+        });
+      }
+
+      debug('  - Balance: %s %s, Securities: %d', balance, currency, securities.length);
+
+      if (balance !== 0 || securities.length > 0) {
+        const investmentAccountNumber = `${account.bankNumber}-${account.accountNumber}-investment`;
+
+        accounts.push({
+          accountNumber: investmentAccountNumber,
+          balance,
+          currency,
+          savingsAccount: true,
+          txns: [],
+          securities,
+        });
+
+        debug('  ✓ Added investment account: %s with %d securities', investmentAccountNumber, securities.length);
+      } else {
+        debug('  - Skipping (zero balance and no securities)');
+      }
+    } else {
+      debug('  - No investment account data found');
+    }
+  } catch (error) {
+    debug('  - Error fetching investment account: %s', error);
+    // Log more details about the error
+    if (error instanceof Error) {
+      debug('    Error message: %s', error.message);
+      debug('    Error stack: %s', error.stack);
+    }
+  } finally {
+    // Clean up request interception (in case it wasn't already done)
+    try {
+      page.off('request', requestHandler);
+      await page.setRequestInterception(false);
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+  }
+
+  debug('Returning %d investment accounts', accounts.length);
+  return accounts;
+}
+
 async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOptions) {
   const restContext = await getRestContext(page);
   const apiSiteUrl = `${baseUrl}/${restContext}`;
@@ -442,6 +655,15 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
       debug('Added %d savings accounts to results', savingsAccounts.length);
     } catch (error) {
       debug('Error fetching savings accounts for %s: %s', accountNumber, error);
+    }
+
+    // Fetch investment accounts for this account number
+    try {
+      const investmentAccounts = await getInvestmentAccounts(baseUrl, page, account);
+      accounts.push(...investmentAccounts);
+      debug('Added %d investment accounts to results', investmentAccounts.length);
+    } catch (error) {
+      debug('Error fetching investment accounts for %s: %s', accountNumber, error);
     }
   }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -126,7 +126,7 @@ interface InvestmentSecurityBalance {
   BaseRate?: number;
   LastRate?: number;
   BaseRateChangePercentage?: number;
-  OnlineNV?: number;
+  OnlineNV: number;
   OnlineVL: number;
   OnlineNisVL?: number;
   ProfitLoss?: number;
@@ -543,6 +543,7 @@ async function getInvestmentAccounts(
         securities.push({
           name: meta?.EngName || '',
           symbol: meta?.EngSymbol || '',
+          volume: securityBalance.OnlineNV,
           value: securityBalance.OnlineVL,
           currency: securityBalance.CurrencyCode || meta?.CurrencyCode || SHEKEL_CURRENCY,
           changePercentage: securityBalance.BaseRateChangePercentage,
@@ -553,8 +554,7 @@ async function getInvestmentAccounts(
       debug('  - Balance: %s %s, Securities: %d', balance, currency, securities.length);
 
       if (balance !== 0 || securities.length > 0) {
-        const investmentAccountNumber = `${account.bankNumber}-${account.accountNumber}-investment`;
-
+        const investmentAccountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}-investment`;
         accounts.push({
           accountNumber: investmentAccountNumber,
           balance,

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -342,8 +342,7 @@ async function getForexAccounts(
 
   const currency = { code: 19, swift: SHEKEL_CURRENCY };
   try {
-    const detailedAccountTypeCode = 142; // For foreign currency accounts
-    const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&currencyCodeList=${currency.code}&detailedAccountTypeCodeList=${detailedAccountTypeCode}&view=details&lang=he`;
+    const forexUrl = `${baseUrl}/ServerServices/foreign-currency/transactions?accountId=${accountNumber}&type=business&retrievalStartDate=${startDate}&retrievalEndDate=${endDate}&lang=he`;
     debug('Trying forex %s', forexUrl);
 
     const forexData = await fetchGetWithinPage<ForexAccountData>(page, forexUrl, true); // ignoreErrors = true
@@ -355,14 +354,8 @@ async function getForexAccounts(
         const currencySwiftCode = currencyData.currencySwiftCode || currency.swift;
         const transactionCount = currencyData.transactions?.length || 0;
 
-        // Get balance from the most recent transaction's currentBalance field
-        // If no transactions, fall back to currencyData.currentBalance
-        let balance = currencyData.currentBalance;
-        if (transactionCount > 0 && currencyData.transactions) {
-          balance = currencyData.transactions[0].currentBalance;
-          debug('  - Using balance from most recent transaction: %s', balance);
-        }
-
+        // Get balance from currencyData.currentBalance
+        const balance = currencyData.currentBalance;
         debug('  - Currency: %s, Balance: %s, Transactions: %d', currencySwiftCode, balance, transactionCount);
 
         // Log transaction dates for debugging
@@ -393,7 +386,6 @@ async function getForexAccounts(
     }
   } catch (error) {
     debug('  - Error fetching forex: %s', error);
-    // Continue trying other currencies
   }
 
   debug('Returning %d forex accounts', accounts.length);

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -475,9 +475,19 @@ async function getInvestmentAccounts(
     await page.setRequestInterception(true);
     page.on('request', requestHandler);
 
-    await page.goto(mytradeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
-    // Wait longer for the page to fully load and establish session
-    await new Promise(resolve => setTimeout(resolve, 5000));
+    // Try to navigate, but if it fails (e.g., MyTrade not enabled), clean up and return empty
+    try {
+      await page.goto(mytradeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+      // Wait longer for the page to fully load and establish session
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    } catch (navError) {
+      debug('  - Navigation to MyTrade failed (likely not enabled): %s', navError);
+      // Clean up request interception
+      page.off('request', requestHandler);
+      await page.setRequestInterception(false);
+      debug('Returning 0 investment accounts (MyTrade not accessible)');
+      return accounts;
+    }
 
     // Now turn off request interception before we make API calls
     page.off('request', requestHandler);
@@ -586,6 +596,18 @@ async function getInvestmentAccounts(
     } catch (e) {
       // Ignore cleanup errors
     }
+
+    // Navigate back to the main homepage to restore the session for subsequent scraping
+    try {
+      const homepageUrl = `${baseUrl}/ng-portals/rb/he/homepage`;
+      debug('Navigating back to homepage: %s', homepageUrl);
+      await page.goto(homepageUrl, { waitUntil: 'networkidle2', timeout: 30000 });
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      debug('Homepage restored');
+    } catch (navError) {
+      debug('  - Failed to navigate back to homepage: %s', navError);
+      // Continue anyway, the outer try-catch in fetchAccountData will handle it
+    }
   }
 
   debug('Returning %d investment accounts', accounts.length);
@@ -620,17 +642,30 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
     debug('getting information for account %s', account.accountNumber);
     const accountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}`;
 
-    const balance = await getAccountBalance(apiSiteUrl, page, accountNumber);
-    const txns = await getAccountTransactions(
-      baseUrl,
-      apiSiteUrl,
-      page,
-      accountNumber,
-      startDateStr,
-      endDateStr,
-      additionalTransactionInformation,
-      options,
-    );
+    let balance;
+    const isActiveAccount = account.accountClosingReasonCode === 0;
+    if (isActiveAccount) {
+      balance = await getAccountBalance(apiSiteUrl, page, accountNumber);
+    } else {
+      debug('Skipping balance for a closed account, balance will be undefined');
+    }
+
+    let txns: Transaction[] = [];
+    try {
+      txns = await getAccountTransactions(
+        baseUrl,
+        apiSiteUrl,
+        page,
+        accountNumber,
+        startDateStr,
+        endDateStr,
+        additionalTransactionInformation,
+        options,
+      );
+    } catch (error) {
+      debug('Error fetching transactions for %s (possibly closed account): %s', accountNumber, error);
+      // Continue with empty transactions
+    }
 
     // Add regular checking account
     accounts.push({

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -327,6 +327,7 @@ async function getForexAccounts(
           accounts.push({
             accountNumber: forexAccountNumber,
             balance,
+            currency: currencySwiftCode,
             txns,
           });
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -359,24 +359,19 @@ async function getSavingsAccounts(baseUrl: string, page: Page, accountNumber: st
   const accounts: TransactionsAccount[] = [];
 
   for (const wrapper of savingsData.depositsWrapperData) {
-    const totalBalance = wrapper.revaluatedAmount || wrapper.amount;
+    // Create a separate account for each individual deposit
+    for (const deposit of wrapper.data) {
+      const balance = deposit.revaluedTotalAmount || deposit.principalAmount;
+      const savingsAccountNumber = `${accountNumber}-${deposit.depositSerialId}`;
 
-    // For savings accounts, we create one account per wrapper with the total balance
-    // Individual deposits don't have transaction history, just balance snapshots
-    const savingsAccountNumber = `${accountNumber}-SAVINGS`;
-
-    // Check if we already added this account (in case of multiple deposits)
-    const existingAccount = accounts.find(acc => acc.accountNumber === savingsAccountNumber);
-
-    if (existingAccount) {
-      // Add to existing balance
-      existingAccount.balance = (existingAccount.balance || 0) + totalBalance;
-    } else {
       accounts.push({
         accountNumber: savingsAccountNumber,
-        balance: totalBalance,
+        savingsAccount: true,
+        balance,
         txns: [], // Savings accounts typically don't have transaction history in the same way
       });
+
+      debug('Added savings account %s with balance %s', savingsAccountNumber, balance);
     }
   }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -6,7 +6,13 @@ import { getDebug } from '../helpers/debug';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { waitForRedirect } from '../helpers/navigation';
 import { waitUntil } from '../helpers/waiting';
-import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount, type Security } from '../transactions';
+import {
+  type Transaction,
+  TransactionStatuses,
+  TransactionTypes,
+  type TransactionsAccount,
+  type Security,
+} from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
 import { type ScraperOptions } from './interface';
 import { getRawTransaction } from '../helpers/transactions';
@@ -422,97 +428,144 @@ async function getInvestmentAccounts(
   account: { bankNumber: string; branchNumber: string; accountNumber: string },
 ): Promise<TransactionsAccount[]> {
   debug('========== FETCHING INVESTMENT ACCOUNTS ==========');
-  const accounts: TransactionsAccount[] = [];
   const accountNumber = `${account.branchNumber}-${account.accountNumber}`; // Don't include bankNumber here because investment API doesn't use it
+  const mytradeUrl = `${baseUrl}/mytrade/app`;
+  const homepageUrl = `${baseUrl}/ng-portals/rb/he/homepage`;
+  const MAX_RETRIES = 3;
 
-  // Set up request interception to capture session headers
-  let capturedSession: string | null = null;
-  let capturedCsession: string | null = null;
-
-  const requestHandler = (request: any) => {
+  const navigateToHomepage = async () => {
     try {
-      const headers = request.headers();
-      if (headers.session && !capturedSession) {
-        capturedSession = headers.session;
-        debug('  - Captured session from network request');
-      }
-      if (headers.csession && !capturedCsession) {
-        capturedCsession = headers.csession;
-        debug('  - Captured csession from network request');
-      }
-      request.continue();
-    } catch (e) {
-      debug('  - Error in request handler: %s', e);
-      // Try to continue anyway
-      try {
-        request.continue();
-      } catch (continueError) {
-        // Ignore if already handled
-      }
+      debug('Navigating back to homepage: %s', homepageUrl);
+      await page.goto(homepageUrl, { waitUntil: 'networkidle2', timeout: 30000 });
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      debug('Homepage restored');
+    } catch (navError) {
+      debug('  - Failed to navigate back to homepage: %s', navError);
     }
   };
 
-  try {
-    // Navigate to mytrade section to establish session
-    const mytradeUrl = `${baseUrl}/mytrade/app`;
-    debug('Navigating to mytrade section: %s', mytradeUrl);
+  // Try to scrape investment accounts multiple times
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 1) {
+      debug('  - Retry attempt %d/%d, waiting 3s...', attempt, MAX_RETRIES);
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
 
-    await page.setRequestInterception(true);
-    page.on('request', requestHandler);
+    // Set up request interception to capture session headers
+    let capturedSession: string | null = null;
+    let capturedCsession: string | null = null;
 
-    // Try to navigate, but if it fails (e.g., MyTrade not enabled), clean up and return empty
+    const requestHandler = (request: any) => {
+      try {
+        const headers = request.headers();
+        if (headers.session && !capturedSession) {
+          capturedSession = headers.session;
+          debug('  - Captured session from network request');
+        }
+        if (headers.csession && !capturedCsession) {
+          capturedCsession = headers.csession;
+          debug('  - Captured csession from network request');
+        }
+        request.continue();
+      } catch (e) {
+        debug('  - Error in request handler: %s', e);
+        // Try to continue anyway
+        try {
+          request.continue();
+        } catch (continueError) {
+          // Ignore if already handled
+        }
+      }
+    };
+
     try {
-      await page.goto(mytradeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
-      // Wait longer for the page to fully load and establish session
-      await new Promise(resolve => setTimeout(resolve, 5000));
-    } catch (navError) {
-      debug('  - Navigation to MyTrade failed (likely not enabled): %s', navError);
-      // Clean up request interception
+      // Navigate to mytrade section to establish session
+      debug('Navigating to mytrade section (attempt %d/%d): %s', attempt, MAX_RETRIES, mytradeUrl);
+      await page.setRequestInterception(true);
+      page.on('request', requestHandler);
+
+      // Try to navigate, but if it fails (e.g., MyTrade not enabled), clean up and return empty
+      try {
+        await page.goto(mytradeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        // Wait longer for the page to fully load and establish session
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      } catch (navError) {
+        debug('  - Navigation to MyTrade failed (likely not enabled): %s', navError);
+        page.off('request', requestHandler);
+        await page.setRequestInterception(false);
+        await navigateToHomepage();
+        debug('Returning 0 investment accounts (MyTrade not accessible)');
+        return [];
+      }
+
       page.off('request', requestHandler);
       await page.setRequestInterception(false);
-      debug('Returning 0 investment accounts (MyTrade not accessible)');
-      return accounts;
-    }
 
-    // Now turn off request interception before we make API calls
-    page.off('request', requestHandler);
-    await page.setRequestInterception(false);
+      // Session headers are required for the investment API - without them the call will fail.
+      // If they weren't captured (e.g. page loaded from cache before the handler was ready), retry.
+      if (!capturedSession || !capturedCsession) {
+        debug(
+          '  - Session headers not captured on attempt %d/%d (session=%s, csession=%s)',
+          attempt,
+          MAX_RETRIES,
+          !!capturedSession,
+          !!capturedCsession,
+        );
+        if (attempt < MAX_RETRIES) {
+          await navigateToHomepage();
+          continue;
+        }
+        debug('  - Could not capture session headers after %d attempts, skipping investment accounts', MAX_RETRIES);
+        break;
+      }
 
-    debug('Mytrade page loaded, session established');
+      debug('Mytrade page loaded, session established');
 
-    const fields =
-      'EngName,EngSymbol,HebName,HebSymbol,Symbol,ExpirationDate,ItemType,StockType,IsEtf,IsForeign,CurrencyCode,Exchange,CreationEquityNum,EquityType,ContractType,AllowedOrderDirection,EquitySubType';
-    const investmentUrl = `${baseUrl}/ServerServices/mytrade/api/v2/json2/account/view?account=${accountNumber}&fields=${fields}`;
-    debug('Trying investment account URL: %s', investmentUrl);
+      const fields =
+        'EngName,EngSymbol,HebName,HebSymbol,Symbol,ExpirationDate,ItemType,StockType,IsEtf,IsForeign,CurrencyCode,Exchange,CreationEquityNum,EquityType,ContractType,AllowedOrderDirection,EquitySubType';
+      const investmentUrl = `${baseUrl}/ServerServices/mytrade/api/v2/json2/account/view?account=${accountNumber}&fields=${fields}`;
+      debug('Fetching investment account data (attempt %d/%d): %s', attempt, MAX_RETRIES, investmentUrl);
 
-    // Get XSRF token and session data from cookies
-    const cookies = await page.cookies();
-    const XSRFCookie = cookies.find(cookie => cookie.name === 'XSRF-TOKEN');
+      // Get XSRF token and session data from cookies
+      const cookies = await page.cookies();
+      const XSRFCookie = cookies.find(cookie => cookie.name === 'XSRF-TOKEN');
 
-    // Use captured session or fallback to generated ones
-    const sessionId = capturedSession || randomUUID();
-    const csession = capturedCsession || Math.random().toString();
+      // Use captured session or fallback to generated ones
+      const headers: Record<string, any> = {
+        'Content-Type': 'application/json; charset=utf-8',
+        csession: capturedCsession,
+        session: capturedSession,
+        Referer: mytradeUrl,
+      };
+      if (XSRFCookie != null) {
+        headers['X-XSRF-TOKEN'] = XSRFCookie.value;
+        debug('  - Using XSRF token: %s', `${XSRFCookie.value.substring(0, 10)}...`);
+      }
 
-    const headers: Record<string, any> = {
-      'Content-Type': 'application/json; charset=utf-8',
-      csession,
-      session: sessionId,
-      Referer: mytradeUrl,
-    };
-    if (XSRFCookie != null) {
-      headers['X-XSRF-TOKEN'] = XSRFCookie.value;
-      debug('  - Using XSRF token: %s', XSRFCookie.value.substring(0, 10) + '...');
-    }
+      const investmentData = await fetchPostWithinPage<InvestmentAccountData>(page, investmentUrl, {}, headers);
 
-    const investmentData = await fetchPostWithinPage<InvestmentAccountData>(page, investmentUrl, {}, headers);
+      debug('  - Response received: %s', investmentData ? 'YES' : 'NO');
+      if (investmentData) {
+        debug('  - Response has View: %s', investmentData.View ? 'YES' : 'NO');
+        debug('  - Response has View.Account: %s', investmentData.View?.Account ? 'YES' : 'NO');
+      }
 
-    debug('  - Response received: %s', investmentData ? 'YES' : 'NO');
-    if (investmentData) {
-      debug('  - Response has View: %s', investmentData.View ? 'YES' : 'NO');
-      debug('  - Response has View.Account: %s', investmentData.View?.Account ? 'YES' : 'NO');
-    }
+      if (!investmentData) {
+        debug('  - No data returned from investment API on attempt %d/%d', attempt, MAX_RETRIES);
+        if (attempt < MAX_RETRIES) {
+          await navigateToHomepage();
+          continue;
+        }
+        debug('  - No data returned after %d attempts, skipping investment accounts', MAX_RETRIES);
+        break;
+      }
 
-    if (investmentData?.View?.Account) {
+      if (!investmentData.View?.Account) {
+        // Valid response but no investment account — don't retry
+        debug('  - No investment account data found');
+        break;
+      }
+
       debug('✓ Found investment account data');
 
       const accountData = investmentData.View.Account;
@@ -549,53 +602,44 @@ async function getInvestmentAccounts(
 
       if (balance !== 0 || securities.length > 0) {
         const investmentAccountNumber = `${account.bankNumber}-${account.branchNumber}-${account.accountNumber}-investment`;
-        accounts.push({
+        const result: TransactionsAccount = {
           accountNumber: investmentAccountNumber,
           balance,
           currency,
           savingsAccount: true,
           txns: [],
           securities,
-        });
-
+        };
         debug('  ✓ Added investment account: %s with %d securities', investmentAccountNumber, securities.length);
-      } else {
-        debug('  - Skipping (zero balance and no securities)');
+        await navigateToHomepage();
+        debug('Returning 1 investment account');
+        return [result];
       }
-    } else {
-      debug('  - No investment account data found');
-    }
-  } catch (error) {
-    debug('  - Error fetching investment account: %s', error);
-    // Log more details about the error
-    if (error instanceof Error) {
-      debug('    Error message: %s', error.message);
-      debug('    Error stack: %s', error.stack);
-    }
-  } finally {
-    // Clean up request interception (in case it wasn't already done)
-    try {
-      page.off('request', requestHandler);
-      await page.setRequestInterception(false);
-    } catch (e) {
-      // Ignore cleanup errors
-    }
 
-    // Navigate back to the main homepage to restore the session for subsequent scraping
-    try {
-      const homepageUrl = `${baseUrl}/ng-portals/rb/he/homepage`;
-      debug('Navigating back to homepage: %s', homepageUrl);
-      await page.goto(homepageUrl, { waitUntil: 'networkidle2', timeout: 30000 });
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      debug('Homepage restored');
-    } catch (navError) {
-      debug('  - Failed to navigate back to homepage: %s', navError);
-      // Continue anyway, the outer try-catch in fetchAccountData will handle it
+      debug('  - Skipping (zero balance and no securities)');
+      break;
+    } catch (error) {
+      debug('  - Error fetching investment account (attempt %d/%d): %s', attempt, MAX_RETRIES, error);
+      // Log more details about the error
+      if (error instanceof Error) {
+        debug('    Error message: %s', error.message);
+        debug('    Error stack: %s', error.stack);
+      }
+    } finally {
+      // Clean up request interception (in case it wasn't already done)
+      try {
+        page.off('request', requestHandler);
+        await page.setRequestInterception(false);
+      } catch (e) {
+        // Ignore cleanup errors
+      }
     }
   }
 
-  debug('Returning %d investment accounts', accounts.length);
-  return accounts;
+  // Navigate back to the main homepage to restore the session for subsequent scraping
+  await navigateToHomepage();
+  debug('Returning 0 investment accounts');
+  return [];
 }
 
 async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOptions) {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,7 +1,8 @@
 export interface TransactionsAccount {
   accountNumber: string;
-  savingsAccount?: boolean;
   balance?: number;
+  currency?: string;
+  savingsAccount?: boolean;
   txns: Transaction[];
 }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,6 +4,7 @@ export interface TransactionsAccount {
   currency?: string;
   savingsAccount?: boolean;
   txns: Transaction[];
+  securities?: Security[];
 }
 
 export enum TransactionTypes {
@@ -51,4 +52,13 @@ export interface Transaction {
   status: TransactionStatuses;
   installments?: TransactionInstallments;
   category?: string;
+}
+
+export interface Security {
+  name?: string;
+  symbol: string;
+  value: number;
+  currency?: string;
+  changePercentage?: number;
+  profitLoss?: number;
 }

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -57,6 +57,7 @@ export interface Transaction {
 export interface Security {
   name?: string;
   symbol: string;
+  volume: number;
   value: number;
   currency?: string;
   changePercentage?: number;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,5 +1,6 @@
 export interface TransactionsAccount {
   accountNumber: string;
+  savingsAccount?: boolean;
   balance?: number;
   txns: Transaction[];
 }

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -58,6 +58,7 @@ export interface Transaction {
 export interface Security {
   name?: string;
   symbol: string;
+  volume: number;
   value: number;
   currency?: string;
   changePercentage?: number;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,6 +4,7 @@ export interface TransactionsAccount {
   currency?: string;
   savingsAccount?: boolean;
   txns: Transaction[];
+  securities?: Security[];
 }
 
 export enum TransactionTypes {
@@ -52,4 +53,13 @@ export interface Transaction {
   installments?: TransactionInstallments;
   category?: string;
   rawTransaction?: unknown;
+}
+
+export interface Security {
+  name?: string;
+  symbol: string;
+  value: number;
+  currency?: string;
+  changePercentage?: number;
+  profitLoss?: number;
 }


### PR DESCRIPTION
- Adds support for scraping transaction history from Bank Hapoalim foreign currency accounts
- Adds support for scraping Bank Hapoalim savings account balances
- Adds support for scraping Bank Hapoalim investment account holdings

Tested locally. New accounts in output look like:
```json
    {
      "accountNumber": "12-XXX-XXXXXX-USD",
      "balance": 1000.00,
      "currency": "USD",
      "txns": [
        {
          "type": "normal",
          "identifier": 10017,
          "date": "2025-10-02T21:00:00.000Z",
          "processedDate": "2025-10-15T21:00:00.000Z",
          "originalAmount": 1000.00,
          "originalCurrency": "USD",
          "chargedAmount": 1000.00,
          "description": "העברה מחו\"ל",
          "status": "completed",
          "memo": "Bob Smith"
        }
      ]
    },
    {
      "accountNumber": "12-XXX-XXXXXX-3382501",
      "savingsAccount": true,
      "balance": 10000.00,
      "txns": []
    },
    {
      "accountNumber": "12-XXX-XXXXXX-investment",
      "balance": 149.98,
      "currency": "ILS",
      "savingsAccount": true,
      "txns": [],
      "securities": [
        {
          "name": "POALIM",
          "symbol": "POLI",
          "volume": 2,
          "value": 149.98,
          "currency": "ILS",
          "changePercentage": -1.04,
          "profitLoss": -1.58
        }
      ]
    }
```
