### PR TITLE
fix(isracard): workaround for bot detection

### DIFF
--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -6,6 +6,14 @@ export async function maskHeadlessUserAgent(page: Page): Promise<void> {
 }
 
 /**
+ * Add random human-like delay
+ */
+export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
+  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+/**
  * Priorities for request interception. The higher the number, the higher the priority.
  * We want to let others to have the ability to override our interception logic therefore we hardcode them.
  */

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -6,14 +6,6 @@ export async function maskHeadlessUserAgent(page: Page): Promise<void> {
 }
 
 /**
- * Add random human-like delay
- */
-export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
-}
-
-/**
  * Priorities for request interception. The higher the number, the higher the priority.
  * We want to let others to have the ability to override our interception logic therefore we hardcode them.
  */

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -72,7 +72,10 @@ export async function fetchGetWithinPage<TResult>(
   }, url);
 
   // Check for automation blocking
-  if (status === 429 || (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))) {
+  if (
+    status === 429 ||
+    (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))
+  ) {
     throw new Error(
       `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
     );

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -72,7 +72,7 @@ export async function fetchGetWithinPage<TResult>(
   }, url);
 
   // Check for automation blocking
-  if (status === 429 || (result && (result.includes('Block Automation') || result.includes('bot detection')))) {
+  if (status === 429 || (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))) {
     throw new Error(
       `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
     );

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -63,3 +63,11 @@ export function runSerial<T>(actions: (() => Promise<T>)[]): Promise<T[]> {
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Add random human-like delay
+ */
+export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
+  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
+  return new Promise(resolve => setTimeout(resolve, delay));
+}

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -3,11 +3,12 @@ import moment, { type Moment } from 'moment';
 import { type Page } from 'puppeteer';
 import { ALT_SHEKEL_CURRENCY, SHEKEL_CURRENCY, SHEKEL_CURRENCY_KEYWORD } from '../constants';
 import { ScraperProgressTypes } from '../definitions';
+import { interceptionPriorities, maskHeadlessUserAgent } from '../helpers/browser';
 import getAllMonthMoments from '../helpers/dates';
 import { getDebug } from '../helpers/debug';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { filterOldTransactions, fixInstallments } from '../helpers/transactions';
-import { runSerial, sleep } from '../helpers/waiting';
+import { randomDelay, runSerial, sleep } from '../helpers/waiting';
 import {
   TransactionStatuses,
   TransactionTypes,
@@ -18,7 +19,6 @@ import {
 import { BaseScraperWithBrowser } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
-import { interceptionPriorities, maskHeadlessUserAgent, randomDelay } from '../helpers/browser';
 
 const RATE_LIMIT = {
   SLEEP_BETWEEN: 2500, // Sweet spot: 2.5s base delay (randomized up to 3s)


### PR DESCRIPTION
- Added more delay during Isracard requests to prevent triggering the bot detection
- Added proper handling for when a request is blocked due to automation detection

Tested locally. Accounts scraped successfully. For example:
```
{
  "success": true,
  "accounts": [
    {
      "accountNumber": "XXXX",
      "txns": [
        {
          "type": "normal",
          "identifier": 754530882,
          "date": "2025-01-22T22:00:00.000Z",
          "processedDate": "2025-02-19T22:00:00.000Z",
          "originalAmount": -7.8,
          "originalCurrency": "ILS",
          "chargedAmount": 0,
          "chargedCurrency": "ILS",
          "description": "פועלים- דמי כרטיס",
          "memo": "הנחה 7.80       ש\"ח מימון כל א",
          "status": "completed"
        }
      ]
    }
  ]
}
```
