### PR TITLE
feat(leumi): Add Savings Accounts

### DIFF
--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -50,4 +50,41 @@ describe('Leumi legacy scraper', () => {
 
     exportTransactions(COMPANY_ID, result.accounts || []);
   });
+
+  maybeTestCompanyAPI(COMPANY_ID)('should include savings accounts', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: COMPANY_ID,
+    };
+
+    const scraper = new LeumiScraper(options);
+    const result = await scraper.scrape(testsConfig.credentials.leumi);
+
+    expect(result).toBeDefined();
+    expect(result.success).toBeTruthy();
+    expect(result.accounts).toBeDefined();
+
+    // Check if any savings accounts are present
+    const savingsAccounts = result.accounts?.filter(account => account.savingsAccount === true);
+
+    console.log('Total accounts:', result.accounts?.length);
+    console.log('Savings accounts found:', savingsAccounts?.length);
+
+    if (savingsAccounts && savingsAccounts.length > 0) {
+      console.log('Savings account details:');
+      savingsAccounts.forEach(account => {
+        console.log(`  - Account: ${account.accountNumber}, Balance: ${account.balance}`);
+      });
+
+      // Verify savings account properties
+      savingsAccounts.forEach(account => {
+        expect(account.savingsAccount).toBe(true);
+        expect(account.accountNumber).toMatch(/ID/);
+        expect(account.balance).toBeDefined();
+        expect(account.txns).toBeDefined();
+      });
+    } else {
+      console.log('No savings accounts found - this may be expected if the test account has no deposits');
+    }
+  });
 });

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,6 +1,8 @@
 export interface TransactionsAccount {
   accountNumber: string;
   balance?: number;
+  currency?: string;
+  savingsAccount?: boolean;
   txns: Transaction[];
 }
 


### PR DESCRIPTION
- Adds support for scraping Bank Leumi savings account balances
- Fixed scraping failing due to the change in the login button element

Tested locally. New accounts in output look like:
```json
{
  "accountNumber": "XXX-XXXX_XX",
  "balance": 1000,
  "txns": [
    {
      "status": "completed",
      "type": "normal",
      "date": "2025-12-21T22:00:00.000Z",
      "processedDate": "2025-12-21T22:00:00.000Z",
      "description": "פקדון אינטרנט",
      "identifier": 134900,
      "memo": "",
      "originalCurrency": "ILS",
      "chargedAmount": -10000,
      "originalAmount": -10000
    }
  ]
},
{
  "accountNumber": "XXX-XXXX_XX-ID_1",
  "savingsAccount": true,
  "balance": 10000,
  "txns": []
}
```