### PR TITLE
ci: update permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The [release pipeline](https://github.com/eshaham/israeli-bank-scrapers/actions/runs/20830310346/job/59842486630) stopped commenting on issues/PRs and shows the following error:

```
[8:13:01 PM] [semantic-release] [@semantic-release/github] › ✖  Not allowed to add a comment to the issue #1037.
[8:13:04 PM] [semantic-release] [@semantic-release/github] › ✖  Not allowed to add a comment to the issue #1031.
[8:13:07 PM] [semantic-release] [@semantic-release/github] › ✖  Not allowed to add a comment to the issue #1035.
[8:13:10 PM] [semantic-release] [@semantic-release/github] › ✖  Not allowed to add a comment to the issue #1036.
```

Looking at https://github.com/semantic-release/semantic-release/blob/master/.github/workflows/release.yml, we need to add the following permisions:
```
      issues: write # to be able to comment on released issues
      pull-requests: write # to be able to comment on released pull requests
```