### PR TITLE
feat(mizrahi): enrich bank transfer transactions with counterparty details

### DIFF
--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -9,7 +9,7 @@ import {
 } from '../helpers/elements-interactions';
 import { fetchPostWithinPage } from '../helpers/fetch';
 import { waitForUrl } from '../helpers/navigation';
-import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
+import { type Transaction, type TransferDetails, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { getDebug } from '../helpers/debug';
@@ -72,6 +72,7 @@ type MoreDetailsResponse = {
 type MoreDetails = {
   entries: Record<string, string>;
   memo: string | undefined;
+  transferDetails: TransferDetails | undefined;
 };
 
 const BASE_WEBSITE_URL = 'https://www.mizrahi-tefahot.co.il';
@@ -163,12 +164,30 @@ async function getExtraTransactionDetails(
       debug('fetch details for', params, 'details:', details);
       if (Array.isArray(details) && details.length > 0) {
         const entries = details.map(record => [record.Label.trim(), record.Value.trim()]);
+        const entriesMap = Object.fromEntries(entries);
+
+        const findValue = (prefix: string) => {
+          const entry = entries.find(([label]) => label.startsWith(prefix));
+          return entry?.[1] || undefined;
+        };
+
+        const transferDetails: TransferDetails = {
+          counterpartyName: findValue('שם'),
+          bank: findValue('בנק'),
+          branch: findValue('סניף'),
+          account: findValue('חשבון'),
+          transferPurpose: findValue('מהות'),
+        };
+
+        const hasTransferDetails = Object.values(transferDetails).some(v => v !== undefined);
+
         return {
-          entries: Object.fromEntries(entries),
+          entries: entriesMap,
           memo: entries
-            .filter(([label]) => ['שם', 'מהות', 'חשבון'].some(key => label.startsWith(key)))
+            .filter(([label]) => ['שם', 'מהות', 'חשבון', 'בנק', 'סניף'].some(key => label.startsWith(key)))
             .map(([label, value]) => `${label} ${value}`)
             .join(', '),
+          transferDetails: hasTransferDetails ? transferDetails : undefined,
         };
       }
     }
@@ -179,6 +198,7 @@ async function getExtraTransactionDetails(
   return {
     entries: {},
     memo: undefined,
+    transferDetails: undefined,
   };
 }
 
@@ -231,6 +251,7 @@ async function convertTransactions(
         chargedAmount: row.MC02SchumEZ,
         description: row.MC02TnuaTeurEZ,
         memo: moreDetails?.memo,
+        transferDetails: moreDetails?.transferDetails,
         status:
           pendingIfTodayTransaction && row.IsTodayTransaction
             ? TransactionStatuses.Pending
@@ -372,9 +393,7 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     const relevantRows = response.body.table.rows.filter(row => row.RecTypeSpecified);
     const oshTxn = await convertTransactions(
       relevantRows,
-      this.options.additionalTransactionInformation
-        ? row => getExtraTransactionDetails(this.page, row, apiHeaders)
-        : () => Promise.resolve({ entries: {}, memo: undefined }),
+      row => getExtraTransactionDetails(this.page, row, apiHeaders),
       this.options.optInFeatures?.includes('mizrahi:pendingIfTodayTransaction'),
       this.options,
     );

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -26,6 +26,14 @@ export interface TransactionInstallments {
   total: number;
 }
 
+export interface TransferDetails {
+  counterpartyName?: string;
+  bank?: string;
+  branch?: string;
+  account?: string;
+  transferPurpose?: string;
+}
+
 export interface Transaction {
   type: TransactionTypes;
   /**
@@ -49,5 +57,6 @@ export interface Transaction {
   status: TransactionStatuses;
   installments?: TransactionInstallments;
   category?: string;
+  transferDetails?: TransferDetails;
   rawTransaction?: unknown;
 }


### PR DESCRIPTION
Bank transfers in Mizrahi (e.g. "העברה באינטרנט") have additional details available via the getMaherBerurimSMF API — counterparty name, bank, branch, account, and transfer purpose. These were previously only fetched when the additionalTransactionInformation option was explicitly set, and the memo filter excluded bank/branch fields.

Global changes:
- Add TransferDetails interface with structured fields (counterpartyName, bank, branch, account, transferPurpose) to Transaction type. Currently only populated by the Mizrahi scraper.

Mizrahi-specific changes:
- Always fetch extra details for transactions that have them (MC02ShowDetailsEZ === '1'), removing the additionalTransactionInformation gate. This is safe because MC02ShowDetailsEZ is only '1' for transactions with details (bank transfers), so no extra API calls are made for others (e.g. credit card charges).
- Populate the new transferDetails field from the getMaherBerurimSMF response
- Include bank (בנק) and branch (סניף) in memo alongside the existing name, purpose, and account fields. Other scrapers do not write to memo.