### PR TITLE
fix(mizrahi): gracefully handle missing pending transactions link

### DIFF
--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -327,7 +327,11 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
   }
 
   private async getPendingTransactions(): Promise<Transaction[]> {
-    await this.page.$eval(`a[href*="${PENDING_TRANSACTIONS_PAGE}"]`, el => (el as HTMLElement).click());
+    const pendingLink = await this.page.$(`a[href*="${PENDING_TRANSACTIONS_PAGE}"]`);
+    if (!pendingLink) {
+      return [];
+    }
+    await pendingLink.click();
     const frame = await waitUntilIframeFound(this.page, f => f.url().includes(PENDING_TRANSACTIONS_IFRAME));
     const isPending = await waitUntilElementFound(frame, pendingTrxIdentifierId)
       .then(() => true)


### PR DESCRIPTION
## Problem

When scraping a Mizrahi Bank account that does not have a pending transactions section, `getPendingTransactions()` throws an unhandled error:

```
Error: failed to find element matching selector "a[href*="/osh/legacy/legacy-Osh-p420"]"
```

This causes the entire account scrape to fail — even though all completed transactions were already fetched successfully.

## Root cause

`$eval` throws when the target element is not found. The method had no guard for the case where the pending transactions link is absent from the page.

## Fix

Use `page.$()` to check for the element first. If the link is not present, return an empty array immediately instead of crashing.

```ts
const pendingLink = await this.page.$(`a[href*="${PENDING_TRANSACTIONS_PAGE}"]`);
if (!pendingLink) {
  return [];
}
await pendingLink.click();
```

This is consistent with how `isPending` is already handled a few lines below (graceful fallback to `[]`).

## Tested

Verified against a real Mizrahi account where the pending transactions link does not appear — scraping now completes successfully with all completed transactions saved.
