### PR TITLE
feat(hapoalim): add 2FA OTP support and device trust persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ See the [OptInFeatures](https://github.com/eshaham/israeli-bank-scrapers/blob/ma
 
 ## Two-Factor Authentication Scrapers
 
-Some companies require two-factor authentication, and as such the scraper cannot be fully automated. When using the relevant scrapers, you have two options:
+Some companies require two-factor authentication, and as such the scraper cannot be fully automated. When using the relevant scrapers, you have three options:
 1. Provide an async callback that knows how to retrieve real time secrets like OTP codes.
 2. When supported by the scraper - provide a "long term token". These are usually available if the financial provider only requires Two-Factor authentication periodically, and not on every login. You can retrieve your long term token from the relevant credit/banking app using reverse engineering and a MITM proxy, or use helper functions that are provided by some Two-Factor Auth scrapers (e.g. OneZero).
+3. Use `deviceTrustData` to persist and restore device identity (cookies and localStorage). After a successful login with OTP, the scraper returns `deviceTrustData` in the result. On subsequent runs, pass it back via the `deviceTrustData` option to skip OTP entirely — the bank recognizes the device and doesn't prompt for verification. Currently supported by Hapoalim (see [Bank Hapoalim scraper](#bank-hapoalim-scraper) for a full example).
 
 
 ```node
@@ -278,6 +279,38 @@ const credentials = {
 };
 ```
 This scraper supports fetching transaction from up to one year.
+
+### Two-Factor Authentication (OTP)
+Hapoalim may require SMS OTP verification when logging in from an unrecognized device. You can handle this by providing an `otpCodeRetriever` callback and optionally persisting device trust data to skip OTP on subsequent runs:
+
+```typescript
+import { createScraper, CompanyTypes } from 'israeli-bank-scrapers';
+
+const scraper = createScraper({
+  companyId: CompanyTypes.hapoalim,
+  startDate: new Date('2024-01-01'),
+  // Optionally inject previously saved trust data to skip OTP
+  deviceTrustData: savedTrustData, // or undefined on first run
+});
+
+const result = await scraper.scrape({
+  userCode: '...',
+  password: '...',
+  otpCodeRetriever: async ({ attempt }) => {
+    // Called when OTP is required. `attempt` starts at 1 (max 3).
+    return await promptUserForOtpCode();
+  },
+});
+
+if (result.success && result.deviceTrustData) {
+  // Save trust data (cookies + localStorage) for next time.
+  // When injected via the deviceTrustData option, the bank recognizes
+  // the device and skips OTP verification.
+  await saveTrustData(result.deviceTrustData);
+}
+```
+
+The `deviceTrustData` option is available for all browser-based scrapers, but the OTP flow is currently specific to Hapoalim.
 
 ## Bank Leumi scraper
 This scraper expects the following credentials object:

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -41,8 +41,8 @@ export function waitUntil<T>(
             setTimeout(wait, interval);
           }
         })
-        .catch(() => {
-          reject();
+        .catch((err) => {
+          reject(err || new Error(description || 'waitUntil test function threw'));
         });
     }
     wait();

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -41,7 +41,7 @@ export function waitUntil<T>(
             setTimeout(wait, interval);
           }
         })
-        .catch((err) => {
+        .catch(err => {
           reject(err || new Error(description || 'waitUntil test function threw'));
         });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { default as createScraper } from './scrapers/factory';
 export {
   ScraperLoginResult as ScaperLoginResult,
   ScraperScrapingResult as ScaperScrapingResult,
+  DeviceTrustData,
   Scraper,
   ScraperCredentials,
   ScraperLoginResult,

--- a/src/scrapers/base-scraper-with-browser.test.ts
+++ b/src/scrapers/base-scraper-with-browser.test.ts
@@ -65,6 +65,23 @@ describe('Device trust data', () => {
       expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), { k: 'v' });
     });
 
+    test('with an invalid origin, falls back to the most specific host-only cookie domain', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, {
+        cookies: [
+          { name: 'wildcard', value: '1', domain: '.bankhapoalim.co.il' },
+          { name: 'login', value: '2', domain: 'login.bankhapoalim.co.il' },
+        ] as DeviceTrustData['cookies'],
+        localStorage: { k: 'v' },
+        origin: 'not-an-origin',
+      });
+
+      expect(page.goto).toHaveBeenCalledWith('https://login.bankhapoalim.co.il', { waitUntil: 'domcontentloaded' });
+      expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), { k: 'v' });
+    });
+
     test('skips localStorage restore when no origin can be determined', async () => {
       const page = createMockPage();
       const scraper = scraperWithMockPage(page);

--- a/src/scrapers/base-scraper-with-browser.test.ts
+++ b/src/scrapers/base-scraper-with-browser.test.ts
@@ -1,7 +1,173 @@
 import { extendAsyncTimeout, getTestsConfig } from '../tests/tests-utils';
 import { BaseScraperWithBrowser } from './base-scraper-with-browser';
+import { type DeviceTrustData, type ScraperOptions } from './interface';
 
 const testsConfig = getTestsConfig();
+
+/** Minimal options good enough to construct a scraper without launching a browser. */
+function buildOptions(): ScraperOptions {
+  return { companyId: 'test', startDate: new Date() } as unknown as ScraperOptions;
+}
+
+/** A puppeteer `Page` stand-in that records the device-trust calls without a real browser. */
+function createMockPage(overrides: Record<string, unknown> = {}) {
+  return {
+    setCookie: jest.fn().mockResolvedValue(undefined),
+    goto: jest.fn().mockResolvedValue(undefined),
+    evaluate: jest.fn().mockResolvedValue(undefined),
+    cookies: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+/** Build a scraper with its private `page` replaced by a mock. */
+function scraperWithMockPage(page: ReturnType<typeof createMockPage>) {
+  const scraper = new BaseScraperWithBrowser(buildOptions());
+  (scraper as any).page = page;
+  return scraper;
+}
+
+const injectTrust = (scraper: any, data: DeviceTrustData) => scraper.injectDeviceTrustData(data);
+const extractTrust = (scraper: any): Promise<DeviceTrustData> => scraper.extractDeviceTrustData();
+
+describe('Device trust data', () => {
+  describe('injectDeviceTrustData', () => {
+    test('restores localStorage on the recorded origin', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, {
+        cookies: [{ name: 'a', value: 'b', domain: 'login.bankhapoalim.co.il' }] as DeviceTrustData['cookies'],
+        localStorage: { RFDEVICEID: 'xyz' },
+        origin: 'https://login.bankhapoalim.co.il',
+      });
+
+      expect(page.setCookie).toHaveBeenCalledWith({ name: 'a', value: 'b', domain: 'login.bankhapoalim.co.il' });
+      expect(page.goto).toHaveBeenCalledWith('https://login.bankhapoalim.co.il', { waitUntil: 'domcontentloaded' });
+      expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), { RFDEVICEID: 'xyz' });
+    });
+
+    test('without an origin, falls back to the most specific host-only cookie domain', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, {
+        cookies: [
+          { name: 'wildcard', value: '1', domain: '.bankhapoalim.co.il' }, // parent wildcard — ignored
+          { name: 'short', value: '2', domain: 'bankhapoalim.co.il' }, // host-only, shorter
+          { name: 'long', value: '3', domain: 'login.bankhapoalim.co.il' }, // host-only, most specific
+        ] as DeviceTrustData['cookies'],
+        localStorage: { k: 'v' },
+      });
+
+      // The most specific host-only domain wins, not the first cookie's (often wildcard) domain.
+      expect(page.goto).toHaveBeenCalledWith('https://login.bankhapoalim.co.il', { waitUntil: 'domcontentloaded' });
+      expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), { k: 'v' });
+    });
+
+    test('skips localStorage restore when no origin can be determined', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, {
+        // only a wildcard domain — not usable as an origin
+        cookies: [{ name: 'a', value: '1', domain: '.bankhapoalim.co.il' }] as DeviceTrustData['cookies'],
+        localStorage: { k: 'v' },
+      });
+
+      expect(page.setCookie).toHaveBeenCalledTimes(1); // cookies are still restored
+      expect(page.goto).not.toHaveBeenCalled();
+      expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    test('skips navigation when there is no localStorage to restore', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, {
+        cookies: [{ name: 'a', value: 'b', domain: 'login.bankhapoalim.co.il' }] as DeviceTrustData['cookies'],
+        localStorage: {},
+        origin: 'https://login.bankhapoalim.co.il',
+      });
+
+      expect(page.setCookie).toHaveBeenCalledTimes(1);
+      expect(page.goto).not.toHaveBeenCalled();
+      expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    test('does nothing (and does not throw) on empty trust data', async () => {
+      const page = createMockPage();
+      const scraper = scraperWithMockPage(page);
+
+      await injectTrust(scraper, { cookies: [], localStorage: {} });
+
+      expect(page.setCookie).not.toHaveBeenCalled();
+      expect(page.goto).not.toHaveBeenCalled();
+      expect(page.evaluate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('extractDeviceTrustData', () => {
+    test('serializes only the whitelisted cookie fields plus localStorage and origin', async () => {
+      const page = createMockPage({
+        cookies: jest.fn().mockResolvedValue([
+          {
+            name: 'a',
+            value: 'b',
+            domain: 'login.bankhapoalim.co.il',
+            path: '/',
+            expires: -1,
+            httpOnly: true,
+            secure: true,
+            sameSite: 'Lax',
+            // fields that must NOT be persisted:
+            size: 42,
+            session: false,
+          },
+        ]),
+        evaluate: jest
+          .fn()
+          .mockResolvedValueOnce({ RFDEVICEID: 'xyz' }) // localStorage snapshot
+          .mockResolvedValueOnce('https://login.bankhapoalim.co.il'), // window.location.origin
+      });
+      const scraper = scraperWithMockPage(page);
+
+      const data = await extractTrust(scraper);
+
+      expect(data.cookies).toEqual([
+        {
+          name: 'a',
+          value: 'b',
+          domain: 'login.bankhapoalim.co.il',
+          path: '/',
+          expires: -1,
+          httpOnly: true,
+          secure: true,
+          sameSite: 'Lax',
+        },
+      ]);
+      expect(data.localStorage).toEqual({ RFDEVICEID: 'xyz' });
+      expect(data.origin).toBe('https://login.bankhapoalim.co.il');
+    });
+  });
+
+  test('round-trip: extracted trust is re-injected on the same origin', async () => {
+    const extractPage = createMockPage({
+      cookies: jest.fn().mockResolvedValue([{ name: 'a', value: 'b', domain: 'login.bankhapoalim.co.il' }]),
+      evaluate: jest
+        .fn()
+        .mockResolvedValueOnce({ RFDEVICEID: 'xyz' })
+        .mockResolvedValueOnce('https://login.bankhapoalim.co.il'),
+    });
+    const extracted = await extractTrust(scraperWithMockPage(extractPage));
+
+    const injectPage = createMockPage();
+    await injectTrust(scraperWithMockPage(injectPage), extracted);
+
+    expect(injectPage.goto).toHaveBeenCalledWith('https://login.bankhapoalim.co.il', { waitUntil: 'domcontentloaded' });
+    expect(injectPage.evaluate).toHaveBeenCalledWith(expect.any(Function), { RFDEVICEID: 'xyz' });
+  });
+});
 
 function isNoSandbox(browser: any) {
   const args = browser._process.spawnargs;

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -5,7 +5,7 @@ import { clickButton, fillInput, waitUntilElementFound } from '../helpers/elemen
 import { getCurrentUrl, waitForNavigation } from '../helpers/navigation';
 import { BaseScraper } from './base-scraper';
 import { ScraperErrorTypes } from './errors';
-import { type ScraperCredentials, type ScraperScrapingResult } from './interface';
+import { type DeviceTrustData, type ScraperCredentials, type ScraperScrapingResult } from './interface';
 
 const debug = getDebug('base-scraper-with-browser');
 
@@ -85,6 +85,8 @@ async function safeCleanup(cleanup: () => Promise<void>) {
 class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends BaseScraper<TCredentials> {
   private cleanups: Array<() => Promise<void>> = [];
 
+  private extractedDeviceTrustData?: DeviceTrustData;
+
   private defaultViewportSize = {
     width: 1024,
     height: 768,
@@ -134,6 +136,10 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     this.page.on('requestfailed', request => {
       debug('Request failed: %s %s', request.failure()?.errorText, request.url());
     });
+
+    if (this.options.deviceTrustData) {
+      await this.injectDeviceTrustData(this.options.deviceTrustData);
+    }
   }
 
   private async initializePage() {
@@ -286,6 +292,14 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     return this.handleLoginResult(loginResult);
   }
 
+  async scrape(credentials: TCredentials): Promise<ScraperScrapingResult> {
+    const result = await super.scrape(credentials);
+    if (this.extractedDeviceTrustData) {
+      result.deviceTrustData = this.extractedDeviceTrustData;
+    }
+    return result;
+  }
+
   async terminate(_success: boolean) {
     debug(`terminating browser with success = ${_success}`);
     this.emitProgress(ScraperProgressTypes.Terminating);
@@ -298,8 +312,58 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       });
     }
 
+    if (_success && this.page) {
+      try {
+        this.extractedDeviceTrustData = await this.extractDeviceTrustData();
+        debug('extracted device trust data: %d cookies, %d localStorage entries',
+          this.extractedDeviceTrustData.cookies.length,
+          Object.keys(this.extractedDeviceTrustData.localStorage).length);
+      } catch (e) {
+        debug(`failed to extract device trust data: ${(e as Error).message}`);
+      }
+    }
+
     await Promise.all(this.cleanups.reverse().map(safeCleanup));
     this.cleanups = [];
+  }
+
+  private async injectDeviceTrustData(data: DeviceTrustData) {
+    debug('injecting device trust data');
+    if (data.cookies?.length) {
+      await this.page.setCookie(...data.cookies);
+      debug(`injected ${data.cookies.length} cookies`);
+    }
+    if (data.localStorage && Object.keys(data.localStorage).length) {
+      const domain = data.cookies?.find(c => c.domain)?.domain?.replace(/^\./, '');
+      if (domain) {
+        await this.page.goto(`https://${domain}`, { waitUntil: 'domcontentloaded' });
+        await this.page.evaluate((items: Record<string, string>) => {
+          for (const [key, value] of Object.entries(items)) {
+            window.localStorage.setItem(key, value);
+          }
+        }, data.localStorage);
+        debug(`injected ${Object.keys(data.localStorage).length} localStorage entries`);
+      }
+    }
+  }
+
+  private async extractDeviceTrustData(): Promise<DeviceTrustData> {
+    const rawCookies = await this.page.cookies();
+    const cookies = rawCookies.map(({ name, value, domain, path, expires, httpOnly, secure, sameSite }) => ({
+      name, value, domain, path, expires, httpOnly, secure,
+      sameSite: sameSite as DeviceTrustData['cookies'][number]['sameSite'],
+    }));
+
+    const localStorage = await this.page.evaluate(() => {
+      const items: Record<string, string> = {};
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i)!;
+        items[key] = window.localStorage.getItem(key)!;
+      }
+      return items;
+    });
+
+    return { cookies, localStorage };
   }
 
   private handleLoginResult(loginResult: LoginResults) {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -364,7 +364,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       expires,
       httpOnly,
       secure,
-      sameSite: sameSite as DeviceTrustData['cookies'][number]['sameSite'],
+      sameSite,
     }));
 
     const localStorage = await this.page.evaluate(() => {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -297,8 +297,9 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
   }
 
   async scrape(credentials: TCredentials): Promise<ScraperScrapingResult> {
+    this.extractedDeviceTrustData = undefined;
     const result = await super.scrape(credentials);
-    if (this.extractedDeviceTrustData) {
+    if (result.success && this.extractedDeviceTrustData) {
       result.deviceTrustData = this.extractedDeviceTrustData;
     }
     return result;
@@ -319,9 +320,11 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     if (_success && this.page) {
       try {
         this.extractedDeviceTrustData = await this.extractDeviceTrustData();
-        debug('extracted device trust data: %d cookies, %d localStorage entries',
+        debug(
+          'extracted device trust data: %d cookies, %d localStorage entries',
           this.extractedDeviceTrustData.cookies.length,
-          Object.keys(this.extractedDeviceTrustData.localStorage).length);
+          Object.keys(this.extractedDeviceTrustData.localStorage).length,
+        );
       } catch (e) {
         debug(`failed to extract device trust data: ${(e as Error).message}`);
       }
@@ -354,7 +357,13 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
   private async extractDeviceTrustData(): Promise<DeviceTrustData> {
     const rawCookies = await this.page.cookies();
     const cookies = rawCookies.map(({ name, value, domain, path, expires, httpOnly, secure, sameSite }) => ({
-      name, value, domain, path, expires, httpOnly, secure,
+      name,
+      value,
+      domain,
+      path,
+      expires,
+      httpOnly,
+      secure,
       sameSite: sameSite as DeviceTrustData['cookies'][number]['sameSite'],
     }));
 

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -82,6 +82,15 @@ async function safeCleanup(cleanup: () => Promise<void>) {
   }
 }
 
+function isValidHttpOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.origin === origin && (url.protocol === 'https:' || url.protocol === 'http:');
+  } catch {
+    return false;
+  }
+}
+
 class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends BaseScraper<TCredentials> {
   private cleanups: Array<() => Promise<void>> = [];
 
@@ -341,7 +350,7 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       debug(`injected ${data.cookies.length} cookies`);
     }
     if (data.localStorage && Object.keys(data.localStorage).length) {
-      // localStorage is origin-scoped — it MUST be restored on the same origin it was captured
+      // localStorage is origin-scoped; it must be restored on the same origin it was captured
       // from, otherwise the bank's login JS reads an empty device-trust id and re-challenges 2FA.
       // Prefer the recorded origin; fall back (for older trust data) to the most specific
       // host-only cookie domain rather than the first cookie's (often a wildcard parent) domain.
@@ -349,7 +358,12 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
         .map(c => c.domain)
         .filter((d): d is string => !!d && !d.startsWith('.'))
         .sort((a, b) => b.length - a.length)[0];
-      const origin = data.origin ?? (fallbackDomain ? `https://${fallbackDomain}` : undefined);
+      const origin =
+        data.origin && isValidHttpOrigin(data.origin)
+          ? data.origin
+          : fallbackDomain
+            ? `https://${fallbackDomain}`
+            : undefined;
       if (origin) {
         await this.page.goto(origin, { waitUntil: 'domcontentloaded' });
         await this.page.evaluate((items: Record<string, string>) => {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -341,15 +341,23 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       debug(`injected ${data.cookies.length} cookies`);
     }
     if (data.localStorage && Object.keys(data.localStorage).length) {
-      const domain = data.cookies?.find(c => c.domain)?.domain?.replace(/^\./, '');
-      if (domain) {
-        await this.page.goto(`https://${domain}`, { waitUntil: 'domcontentloaded' });
+      // localStorage is origin-scoped — it MUST be restored on the same origin it was captured
+      // from, otherwise the bank's login JS reads an empty device-trust id and re-challenges 2FA.
+      // Prefer the recorded origin; fall back (for older trust data) to the most specific
+      // host-only cookie domain rather than the first cookie's (often a wildcard parent) domain.
+      const fallbackDomain = (data.cookies ?? [])
+        .map(c => c.domain)
+        .filter((d): d is string => !!d && !d.startsWith('.'))
+        .sort((a, b) => b.length - a.length)[0];
+      const origin = data.origin ?? (fallbackDomain ? `https://${fallbackDomain}` : undefined);
+      if (origin) {
+        await this.page.goto(origin, { waitUntil: 'domcontentloaded' });
         await this.page.evaluate((items: Record<string, string>) => {
           for (const [key, value] of Object.entries(items)) {
             window.localStorage.setItem(key, value);
           }
         }, data.localStorage);
-        debug(`injected ${Object.keys(data.localStorage).length} localStorage entries`);
+        debug(`injected ${Object.keys(data.localStorage).length} localStorage entries at ${origin}`);
       }
     }
   }
@@ -376,7 +384,9 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       return items;
     });
 
-    return { cookies, localStorage };
+    const origin = await this.page.evaluate(() => window.location.origin);
+
+    return { cookies, localStorage, origin };
   }
 
   private handleLoginResult(loginResult: LoginResults) {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -138,7 +138,11 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
     });
 
     if (this.options.deviceTrustData) {
-      await this.injectDeviceTrustData(this.options.deviceTrustData);
+      try {
+        await this.injectDeviceTrustData(this.options.deviceTrustData);
+      } catch (e) {
+        debug(`failed to inject device trust data, continuing without it: ${(e as Error).message}`);
+      }
     }
   }
 
@@ -387,6 +391,12 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
         return {
           success: false,
           errorType: ScraperErrorTypes.ChangePassword,
+        };
+      case LoginResults.TwoFactorRetrieverMissing:
+        this.emitProgress(ScraperProgressTypes.LoginFailed);
+        return {
+          success: false,
+          errorType: ScraperErrorTypes.TwoFactorRetrieverMissing,
         };
       default:
         throw new Error(`unexpected login result "${loginResult}"`);

--- a/src/scrapers/hapoalim.test.ts
+++ b/src/scrapers/hapoalim.test.ts
@@ -1,10 +1,16 @@
 import HapoalimScraper from './hapoalim';
 import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
-import { LoginResults } from './base-scraper-with-browser';
+import { CompanyTypes, SCRAPERS } from '../definitions';
+import { BaseScraperWithBrowser, LoginResults } from './base-scraper-with-browser';
+import { ScraperErrorTypes } from './errors';
+import { type ScraperOptions } from './interface';
 
 const COMPANY_ID = 'hapoalim'; // TODO this property should be hard-coded in the provider
 const testsConfig = getTestsConfig();
+
+function buildScraper(): HapoalimScraper {
+  return new HapoalimScraper({ companyId: CompanyTypes.hapoalim, startDate: new Date() } as unknown as ScraperOptions);
+}
 
 describe('Hapoalim legacy scraper', () => {
   beforeAll(() => {
@@ -49,5 +55,80 @@ describe('Hapoalim legacy scraper', () => {
     expect(result.success).toBeTruthy();
 
     exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});
+
+describe('Hapoalim 2FA (OTP)', () => {
+  describe('OTP-form detection', () => {
+    function getOtpDetector() {
+      const loginOptions = buildScraper().getLoginOptions({ userCode: 'x', password: 'y' });
+      const conditions = loginOptions.possibleResults[LoginResults.TwoFactorRetrieverMissing];
+      expect(Array.isArray(conditions)).toBe(true);
+      const detector = conditions![0];
+      expect(typeof detector).toBe('function');
+      return detector as (options?: { page?: any }) => Promise<boolean>;
+    }
+
+    test('detects the OTP form by selector', async () => {
+      const detector = getOtpDetector();
+      const page = { $: jest.fn().mockResolvedValue({}) };
+
+      await expect(detector({ page })).resolves.toBe(true);
+      expect(page.$).toHaveBeenCalledWith('form.auth-otp-login');
+    });
+
+    test('returns false when the OTP form is absent', async () => {
+      const detector = getOtpDetector();
+      const page = { $: jest.fn().mockResolvedValue(null) };
+
+      await expect(detector({ page })).resolves.toBe(false);
+    });
+
+    test('returns false when no page is available', async () => {
+      const detector = getOtpDetector();
+
+      await expect(detector({})).resolves.toBe(false);
+      await expect(detector(undefined)).resolves.toBe(false);
+    });
+  });
+
+  describe('login override', () => {
+    let superLogin: jest.SpyInstance;
+
+    beforeEach(() => {
+      superLogin = jest.spyOn(BaseScraperWithBrowser.prototype, 'login');
+    });
+
+    afterEach(() => {
+      superLogin.mockRestore();
+    });
+
+    test('fails with TwoFactorRetrieverMissing when 2FA is required but no otpCodeRetriever is provided', async () => {
+      superLogin.mockResolvedValue({ success: false, errorType: ScraperErrorTypes.TwoFactorRetrieverMissing });
+
+      const result = await buildScraper().login({ userCode: 'x', password: 'y' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorType).toBe(ScraperErrorTypes.TwoFactorRetrieverMissing);
+      expect(result.errorMessage).toMatch(/OTP code retriever/i);
+    });
+
+    test('passes a successful login through unchanged', async () => {
+      superLogin.mockResolvedValue({ success: true });
+
+      const result = await buildScraper().login({ userCode: 'x', password: 'y' });
+
+      expect(result.success).toBe(true);
+    });
+
+    test('does not start the OTP flow for non-2FA login errors', async () => {
+      superLogin.mockResolvedValue({ success: false, errorType: ScraperErrorTypes.InvalidPassword });
+      const otpCodeRetriever = jest.fn().mockResolvedValue('123456');
+
+      const result = await buildScraper().login({ userCode: 'x', password: 'y', otpCodeRetriever });
+
+      expect(result.errorType).toBe(ScraperErrorTypes.InvalidPassword);
+      expect(otpCodeRetriever).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -2,7 +2,6 @@ import moment from 'moment';
 import { type Page } from 'puppeteer';
 import { randomUUID } from 'crypto';
 import { getDebug } from '../helpers/debug';
-
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { getCurrentUrl } from '../helpers/navigation';
 import { sleep, waitUntil } from '../helpers/waiting';
@@ -357,7 +356,9 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
 
       for (let i = 0; i < otpInputs.length; i++) {
         await otpInputs[i].click();
-        await otpInputs[i].evaluate((el) => { (el as HTMLInputElement).value = ''; });
+        await otpInputs[i].evaluate(el => {
+          el.value = '';
+        });
         if (i < otpCode.length) {
           await otpInputs[i].type(otpCode[i], { delay: 50 });
         }
@@ -369,9 +370,8 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       // which Angular ignores.
       await this.page.click(OTP_SUBMIT_SELECTOR);
 
-      let otpResult: string;
       try {
-        otpResult = await waitUntil(
+        await waitUntil(
           async () => {
             const otpForm = await this.page.$(OTP_FORM_SELECTOR);
             const errorEl = await this.page.$(OTP_ERROR_SELECTOR);
@@ -388,7 +388,6 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       } catch {
         // Timeout: error selector didn't match but form is still showing — treat as wrong OTP
         debug('OTP waitUntil timed out — treating as wrong OTP');
-        otpResult = 'error';
       }
 
       if (!(await this.page.$(OTP_FORM_SELECTOR))) {

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -2,12 +2,14 @@ import moment from 'moment';
 import { type Page } from 'puppeteer';
 import { randomUUID } from 'crypto';
 import { getDebug } from '../helpers/debug';
+import { clickButton } from '../helpers/elements-interactions';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
-import { waitForRedirect } from '../helpers/navigation';
+import { getCurrentUrl, waitForRedirect } from '../helpers/navigation';
 import { waitUntil } from '../helpers/waiting';
 import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
-import { type ScraperOptions } from './interface';
+import { ScraperErrorTypes } from './errors';
+import { type ScraperLoginResult, type ScraperOptions } from './interface';
 import { getRawTransaction } from '../helpers/transactions';
 
 const debug = getDebug('hapoalim');
@@ -255,6 +257,9 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
   return accountData;
 }
 
+const OTP_FORM_SELECTOR = 'form.auth-otp-login';
+const OTP_SUBMIT_SELECTOR = '.btn-red_1';
+
 function getPossibleLoginResults(baseUrl: string) {
   const urls: PossibleLoginResults = {};
   urls[LoginResults.Success] = [
@@ -269,6 +274,12 @@ function getPossibleLoginResults(baseUrl: string) {
     `${baseUrl}/MCP/START?flow=MCP&state=START&expiredDate=null`,
     /\/ABOUTTOEXPIRE\/START/i,
   ];
+  urls[LoginResults.TwoFactorRetrieverMissing] = [
+    async (options?: { page?: Page }) => {
+      if (!options?.page) return false;
+      return !!(await options.page.$(OTP_FORM_SELECTOR));
+    },
+  ];
   return urls;
 }
 
@@ -279,7 +290,11 @@ function createLoginFields(credentials: ScraperSpecificCredentials) {
   ];
 }
 
-type ScraperSpecificCredentials = { userCode: string; password: string };
+type ScraperSpecificCredentials = {
+  userCode: string;
+  password: string;
+  otpCodeRetriever?: () => Promise<string>;
+};
 
 class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
   get baseUrl() {
@@ -293,6 +308,51 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       submitButtonSelector: '.login-btn',
       postAction: async () => waitForRedirect(this.page),
       possibleResults: getPossibleLoginResults(this.baseUrl),
+    };
+  }
+
+  async login(credentials: ScraperSpecificCredentials): Promise<ScraperLoginResult> {
+    const result = await super.login(credentials);
+
+    if (result.success || result.errorType !== ScraperErrorTypes.TwoFactorRetrieverMissing) {
+      return result;
+    }
+
+    // 2FA page detected — need OTP
+    if (!credentials.otpCodeRetriever) {
+      debug('2FA required but no otpCodeRetriever provided');
+      return {
+        success: false,
+        errorType: ScraperErrorTypes.TwoFactorRetrieverMissing,
+        errorMessage: 'OTP code retriever is required for Hapoalim 2FA',
+      };
+    }
+
+    debug('2FA page detected, requesting OTP from caller');
+    const otpCode = await credentials.otpCodeRetriever();
+
+    debug('entering OTP code');
+    const otpInputs = await this.page.$$(`${OTP_FORM_SELECTOR} input`);
+    for (let i = 0; i < otpCode.length && i < otpInputs.length; i++) {
+      await otpInputs[i].type(otpCode[i]);
+    }
+
+    debug('submitting OTP');
+    await clickButton(this.page, OTP_SUBMIT_SELECTOR);
+    await waitForRedirect(this.page);
+
+    const current = await getCurrentUrl(this.page, true);
+    const successPatterns = ['/portalserver/HomePage', '/ng-portals-bt/rb/he/homepage', '/ng-portals/rb/he/homepage'];
+    if (successPatterns.some(p => current.includes(p))) {
+      debug('OTP verification succeeded');
+      return { success: true };
+    }
+
+    debug('OTP verification failed, current url: %s', current);
+    return {
+      success: false,
+      errorType: ScraperErrorTypes.General,
+      errorMessage: 'OTP verification failed',
     };
   }
 

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import { getDebug } from '../helpers/debug';
 import { clickButton } from '../helpers/elements-interactions';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
-import { getCurrentUrl, waitForRedirect } from '../helpers/navigation';
+import { getCurrentUrl } from '../helpers/navigation';
 import { waitUntil } from '../helpers/waiting';
 import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
@@ -259,6 +259,7 @@ async function fetchAccountData(page: Page, baseUrl: string, options: ScraperOpt
 
 const OTP_FORM_SELECTOR = 'form.auth-otp-login';
 const OTP_SUBMIT_SELECTOR = '.btn-red_1';
+const OTP_ERROR_SELECTOR = '.errors-rb .error-message, .auth-otp-login .error';
 
 function getPossibleLoginResults(baseUrl: string) {
   const urls: PossibleLoginResults = {};
@@ -293,7 +294,7 @@ function createLoginFields(credentials: ScraperSpecificCredentials) {
 type ScraperSpecificCredentials = {
   userCode: string;
   password: string;
-  otpCodeRetriever?: () => Promise<string>;
+  otpCodeRetriever?: (options?: { attempt: number }) => Promise<string>;
 };
 
 class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
@@ -306,7 +307,19 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       loginUrl: `${this.baseUrl}/cgi-bin/poalwwwc?reqName=getLogonPage`,
       fields: createLoginFields(credentials),
       submitButtonSelector: '.login-btn',
-      postAction: async () => waitForRedirect(this.page),
+      postAction: async () => {
+        const initialUrl = await getCurrentUrl(this.page, true);
+        await waitUntil(
+          async () => {
+            const currentUrl = await getCurrentUrl(this.page, true);
+            if (currentUrl !== initialUrl) return true;
+            return !!(await this.page.$(OTP_FORM_SELECTOR));
+          },
+          'waiting for redirect or OTP form',
+          20000,
+          1000,
+        );
+      },
       possibleResults: getPossibleLoginResults(this.baseUrl),
     };
   }
@@ -328,27 +341,81 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       };
     }
 
-    debug('2FA page detected, requesting OTP from caller');
-    const otpCode = await credentials.otpCodeRetriever();
+    const MAX_OTP_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_OTP_ATTEMPTS; attempt++) {
+      debug(`2FA page detected, requesting OTP from caller (attempt ${attempt}/${MAX_OTP_ATTEMPTS})`);
+      const otpCode = await credentials.otpCodeRetriever({ attempt });
 
-    debug('entering OTP code');
-    const otpInputs = await this.page.$$(`${OTP_FORM_SELECTOR} input`);
-    for (let i = 0; i < otpCode.length && i < otpInputs.length; i++) {
-      await otpInputs[i].type(otpCode[i]);
+      debug('entering OTP code');
+      const otpInputs = await this.page.$$(`${OTP_FORM_SELECTOR} input`);
+      for (let i = 0; i < otpInputs.length; i++) {
+        await otpInputs[i].click({ clickCount: 3 });
+        if (i < otpCode.length) {
+          await otpInputs[i].type(otpCode[i]);
+        } else {
+          await otpInputs[i].press('Backspace');
+        }
+      }
+
+      debug('submitting OTP');
+      await clickButton(this.page, OTP_SUBMIT_SELECTOR);
+
+      await waitUntil(
+        async () => {
+          const otpForm = await this.page.$(OTP_FORM_SELECTOR);
+          const errorEl = await this.page.$(OTP_ERROR_SELECTOR);
+          const url = await getCurrentUrl(this.page, true);
+          debug('OTP poll: form=%s, error=%s, url=%s', !!otpForm, !!errorEl, url);
+          if (!otpForm) return 'success';
+          if (errorEl) return 'error';
+          return false;
+        },
+        'waiting for OTP result',
+        20000,
+        1000,
+      );
+
+      if (!(await this.page.$(OTP_FORM_SELECTOR))) {
+        // OTP form closed — wait for the bank to navigate to homepage
+        const successPatterns = [
+          '/portalserver/HomePage',
+          '/ng-portals-bt/rb/he/homepage',
+          '/ng-portals/rb/he/homepage',
+        ];
+        try {
+          await waitUntil(
+            async () => {
+              const url = await getCurrentUrl(this.page, true);
+              debug('post-OTP navigation poll: url=%s', url);
+              return successPatterns.some(p => url.includes(p));
+            },
+            'waiting for post-OTP navigation',
+            10000,
+            1000,
+          );
+          debug('OTP verification succeeded');
+          return { success: true };
+        } catch {
+          const current = await getCurrentUrl(this.page, true);
+          debug('OTP verification failed, current url: %s', current);
+          return {
+            success: false,
+            errorType: ScraperErrorTypes.General,
+            errorMessage: 'OTP verification failed',
+          };
+        }
+      }
+
+      debug(`OTP attempt ${attempt} failed — inline error detected`);
+      if (attempt === MAX_OTP_ATTEMPTS) {
+        return {
+          success: false,
+          errorType: ScraperErrorTypes.General,
+          errorMessage: `OTP verification failed after ${MAX_OTP_ATTEMPTS} attempts`,
+        };
+      }
     }
 
-    debug('submitting OTP');
-    await clickButton(this.page, OTP_SUBMIT_SELECTOR);
-    await waitForRedirect(this.page);
-
-    const current = await getCurrentUrl(this.page, true);
-    const successPatterns = ['/portalserver/HomePage', '/ng-portals-bt/rb/he/homepage', '/ng-portals/rb/he/homepage'];
-    if (successPatterns.some(p => current.includes(p))) {
-      debug('OTP verification succeeded');
-      return { success: true };
-    }
-
-    debug('OTP verification failed, current url: %s', current);
     return {
       success: false,
       errorType: ScraperErrorTypes.General,

--- a/src/scrapers/hapoalim.ts
+++ b/src/scrapers/hapoalim.ts
@@ -2,10 +2,10 @@ import moment from 'moment';
 import { type Page } from 'puppeteer';
 import { randomUUID } from 'crypto';
 import { getDebug } from '../helpers/debug';
-import { clickButton } from '../helpers/elements-interactions';
+
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { getCurrentUrl } from '../helpers/navigation';
-import { waitUntil } from '../helpers/waiting';
+import { sleep, waitUntil } from '../helpers/waiting';
 import { type Transaction, TransactionStatuses, TransactionTypes, type TransactionsAccount } from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
@@ -311,9 +311,14 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
         const initialUrl = await getCurrentUrl(this.page, true);
         await waitUntil(
           async () => {
-            const currentUrl = await getCurrentUrl(this.page, true);
-            if (currentUrl !== initialUrl) return true;
-            return !!(await this.page.$(OTP_FORM_SELECTOR));
+            try {
+              const currentUrl = await getCurrentUrl(this.page, true);
+              if (currentUrl !== initialUrl) return true;
+              return !!(await this.page.$(OTP_FORM_SELECTOR));
+            } catch {
+              // Navigation destroyed the execution context — page is redirecting, which is progress
+              return true;
+            }
           },
           'waiting for redirect or OTP form',
           20000,
@@ -347,33 +352,44 @@ class HapoalimScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
       const otpCode = await credentials.otpCodeRetriever({ attempt });
 
       debug('entering OTP code');
-      const otpInputs = await this.page.$$(`${OTP_FORM_SELECTOR} input`);
+      const otpInputs = await this.page.$$(`${OTP_FORM_SELECTOR} input[type="text"]`);
+      debug('found %d OTP digit inputs', otpInputs.length);
+
       for (let i = 0; i < otpInputs.length; i++) {
-        await otpInputs[i].click({ clickCount: 3 });
+        await otpInputs[i].click();
+        await otpInputs[i].evaluate((el) => { (el as HTMLInputElement).value = ''; });
         if (i < otpCode.length) {
-          await otpInputs[i].type(otpCode[i]);
-        } else {
-          await otpInputs[i].press('Backspace');
+          await otpInputs[i].type(otpCode[i], { delay: 50 });
         }
+        await sleep(100);
       }
 
       debug('submitting OTP');
-      await clickButton(this.page, OTP_SUBMIT_SELECTOR);
+      // Use page.click() for proper mouse events — clickButton uses synthetic el.click()
+      // which Angular ignores.
+      await this.page.click(OTP_SUBMIT_SELECTOR);
 
-      await waitUntil(
-        async () => {
-          const otpForm = await this.page.$(OTP_FORM_SELECTOR);
-          const errorEl = await this.page.$(OTP_ERROR_SELECTOR);
-          const url = await getCurrentUrl(this.page, true);
-          debug('OTP poll: form=%s, error=%s, url=%s', !!otpForm, !!errorEl, url);
-          if (!otpForm) return 'success';
-          if (errorEl) return 'error';
-          return false;
-        },
-        'waiting for OTP result',
-        20000,
-        1000,
-      );
+      let otpResult: string;
+      try {
+        otpResult = await waitUntil(
+          async () => {
+            const otpForm = await this.page.$(OTP_FORM_SELECTOR);
+            const errorEl = await this.page.$(OTP_ERROR_SELECTOR);
+            const url = await getCurrentUrl(this.page, true);
+            debug('OTP poll: form=%s, error=%s, url=%s', !!otpForm, !!errorEl, url);
+            if (!otpForm) return 'success';
+            if (errorEl) return 'error';
+            return false;
+          },
+          'waiting for OTP result',
+          20000,
+          1000,
+        );
+      } catch {
+        // Timeout: error selector didn't match but form is still showing — treat as wrong OTP
+        debug('OTP waitUntil timed out — treating as wrong OTP');
+        otpResult = 'error';
+      }
 
       if (!(await this.page.$(OTP_FORM_SELECTOR))) {
         // OTP form closed — wait for the bank to navigate to homepage

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -6,7 +6,7 @@ import { type ErrorResult, type ScraperErrorTypes } from './errors';
 // TODO: Remove this type when the scraper 'factory' will return concrete scraper types
 // Instead of a generic interface (which in turn uses this type)
 export type ScraperCredentials =
-  | { userCode: string; password: string; otpCodeRetriever?: () => Promise<string> }
+  | { userCode: string; password: string; otpCodeRetriever?: (options?: { attempt: number }) => Promise<string> }
   | { username: string; password: string }
   | { id: string; password: string }
   | { id: string; password: string; num: string }
@@ -14,7 +14,7 @@ export type ScraperCredentials =
   | { username: string; nationalID: string; password: string }
   | ({ email: string; password: string } & (
       | {
-          otpCodeRetriever: () => Promise<string>;
+          otpCodeRetriever: (options?: { attempt: number }) => Promise<string>;
           phoneNumber: string;
         }
       | {

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -6,7 +6,7 @@ import { type ErrorResult, type ScraperErrorTypes } from './errors';
 // TODO: Remove this type when the scraper 'factory' will return concrete scraper types
 // Instead of a generic interface (which in turn uses this type)
 export type ScraperCredentials =
-  | { userCode: string; password: string }
+  | { userCode: string; password: string; otpCodeRetriever?: () => Promise<string> }
   | { username: string; password: string }
   | { id: string; password: string }
   | { id: string; password: string; num: string }
@@ -27,6 +27,22 @@ export type OptInFeatures =
   | 'mizrahi:pendingIfNoIdentifier'
   | 'mizrahi:pendingIfHasGenericDescription'
   | 'mizrahi:pendingIfTodayTransaction';
+
+export interface DeviceTrustCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+}
+
+export interface DeviceTrustData {
+  cookies: DeviceTrustCookie[];
+  localStorage: Record<string, string>;
+}
 
 export interface FutureDebit {
   amount: number;
@@ -171,6 +187,13 @@ export type ScraperOptions = ScraperBrowserOptions & {
    * Opt-in features for the scrapers, allowing safe rollout of new breaking changes.
    */
   optInFeatures?: Array<OptInFeatures>;
+
+  /**
+   * Device trust data from a previous session. When provided, cookies and localStorage
+   * are injected into the browser before login to avoid repeated 2FA challenges.
+   * Only used by browser-based scrapers.
+   */
+  deviceTrustData?: DeviceTrustData;
 };
 
 export interface OutputDataOptions {
@@ -186,6 +209,13 @@ export interface ScraperScrapingResult {
   futureDebits?: FutureDebit[];
   errorType?: ScraperErrorTypes;
   errorMessage?: string; // only on success=false
+
+  /**
+   * Device trust data extracted after a successful browser-based scrape.
+   * Callers should persist this and pass it back via `ScraperOptions.deviceTrustData`
+   * on subsequent scrapes to avoid repeated 2FA challenges.
+   */
+  deviceTrustData?: DeviceTrustData;
 }
 
 export interface Scraper<TCredentials extends ScraperCredentials> {

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -1,4 +1,4 @@
-import { type BrowserContext, type Browser, type Page } from 'puppeteer';
+import { type BrowserContext, type Browser, type CookieData, type Page } from 'puppeteer';
 import { type CompanyTypes, type ScraperProgressTypes } from '../definitions';
 import { type TransactionsAccount } from '../transactions';
 import { type ErrorResult, type ScraperErrorTypes } from './errors';
@@ -28,19 +28,8 @@ export type OptInFeatures =
   | 'mizrahi:pendingIfHasGenericDescription'
   | 'mizrahi:pendingIfTodayTransaction';
 
-export interface DeviceTrustCookie {
-  name: string;
-  value: string;
-  domain?: string;
-  path?: string;
-  expires?: number;
-  httpOnly?: boolean;
-  secure?: boolean;
-  sameSite?: 'Strict' | 'Lax' | 'None';
-}
-
 export interface DeviceTrustData {
-  cookies: DeviceTrustCookie[];
+  cookies: CookieData[];
   localStorage: Record<string, string>;
 }
 

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -31,6 +31,12 @@ export type OptInFeatures =
 export interface DeviceTrustData {
   cookies: CookieData[];
   localStorage: Record<string, string>;
+  /**
+   * The origin (e.g. https://login.bankhapoalim.co.il) the localStorage was captured from.
+   * localStorage is origin-scoped, so it must be restored on the same origin or the bank's
+   * login JS won't see the device-trust identifier and will re-challenge for 2FA.
+   */
+  origin?: string;
 }
 
 export interface FutureDebit {


### PR DESCRIPTION
## Summary

- Add **device trust persistence** to `BaseScraperWithBrowser` — callers can save and restore cookies/localStorage between sessions to avoid repeated 2FA challenges
- Add **2FA OTP support** to the Hapoalim scraper — when the bank triggers SMS verification, the scraper detects the OTP form and calls an `otpCodeRetriever` callback

Closes #1077

## How it works

**First login (2FA triggered):**
```typescript
const scraper = createScraper({ companyId: CompanyTypes.hapoalim, startDate });
const result = await scraper.scrape({
  userCode: '...',
  password: '...',
  otpCodeRetriever: async () => {
    // prompt user for SMS code
    return '123456';
  },
});
// result.deviceTrustData → save this (~50KB of cookies + localStorage)
```

**Subsequent logins (2FA bypassed):**
```typescript
const scraper = createScraper({
  companyId: CompanyTypes.hapoalim,
  startDate,
  deviceTrustData: savedTrustData, // inject saved trust
});
const result = await scraper.scrape({ userCode: '...', password: '...' });
// result.deviceTrustData → refresh saved data
```

## Changes

### `interface.ts`
- New `DeviceTrustData` type (cookies + localStorage)
- `ScraperCredentials`: `{ userCode, password }` variant now accepts optional `otpCodeRetriever`
- `ScraperOptions`: new `deviceTrustData` field for injecting saved trust
- `ScraperScrapingResult`: new `deviceTrustData` field with extracted trust

### `base-scraper-with-browser.ts`
- `initialize()`: injects cookies and localStorage from `options.deviceTrustData` before login
- `terminate()`: extracts cookies and localStorage after successful scrape
- `scrape()`: attaches extracted trust data to the result
- Generic — available to any browser-based scraper, not just Hapoalim

### `hapoalim.ts`
- OTP form detection via `form.auth-otp-login` DOM element (bank shows OTP overlay on the same URL, no redirect)
- `login()` override: detects 2FA → calls `otpCodeRetriever` → enters digits into individual input fields → submits via `.btn-red_1` button
- Backward compatible: callers without `otpCodeRetriever` get `TwoFactorRetrieverMissing` as before

## Design notes

This takes a different approach than OneZero's 2FA, which is API-based (`triggerTwoFactorAuth` / `getLongTermTwoFactorToken` / `otpLongTermToken`). Hapoalim's 2FA is browser-based — the bank decides when to challenge based on device recognition, and the OTP is entered directly into the browser page. Device trust persistence replaces the concept of a long-term token.

## Test plan

- [x] `createScraper` with `otpCodeRetriever` → 2FA triggered → OTP entered → login succeeds
- [x] `createScraper` with `deviceTrustData` from previous session → login succeeds without 2FA
- [ ] `createScraper` without `otpCodeRetriever` and no trust data → 2FA triggers → returns `TwoFactorRetrieverMissing` (backward compatible)
- [ ] Existing scrapers unaffected (no breaking changes to `BaseScraperWithBrowser` lifecycle)