### PR TITLE
docs: remove broken david-dm.org dependency badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![NPM](https://nodei.co/npm/israeli-bank-scrapers.png)](https://nodei.co/npm/israeli-bank-scrapers/)
 
 [![npm version](https://badge.fury.io/js/israeli-bank-scrapers.svg)](https://badge.fury.io/js/israeli-bank-scrapers)
-[![dependencies Status](https://david-dm.org/eshaham/israeli-bank-scrapers/status.svg)](https://david-dm.org/eshaham/israeli-bank-scrapers)
-[![devDependencies Status](https://david-dm.org/eshaham/israeli-bank-scrapers/dev-status.svg)](https://david-dm.org/eshaham/israeli-bank-scrapers?type=dev)
 [![Discord](https://img.shields.io/discord/924617301209260103?logo=discord)](https://discord.gg/2UvGM7aX4p)
 
 > Important!


### PR DESCRIPTION
The dependencies and devDependencies status badges from david-dm.org have been broken (HTTP 500) since the service was shut down. This PR removes them.

### Changes
- Removed `dependencies Status` badge (david-dm.org)
- Removed `devDependencies Status` badge (david-dm.org)

All remaining badges (NPM, npm version, Discord) are working correctly.