### PR TITLE
feat(yahav): populate TransactionsAccount.balance

### DIFF
--- a/src/scrapers/yahav.ts
+++ b/src/scrapers/yahav.ts
@@ -217,6 +217,23 @@ async function searchByDates(page: Page, startDate: Moment) {
   }
 }
 
+// Yahav does not render a dedicated current-balance field on the statements page — the closest
+// stable value is the running balance on the newest transaction row (last column of the top
+// row), which equals the current account balance after that transaction posted.
+// Returns undefined if the element is missing or the value cannot be parsed.
+async function getCurrentBalance(page: Page): Promise<number | undefined> {
+  try {
+    const balanceStr = await page.$eval(
+      '.transactions .list-item-holder .entire-content-ctr:first-of-type .col:last-child',
+      el => (el as HTMLElement).innerText,
+    );
+    const parsed = parseFloat(balanceStr.replace(/,/g, '').trim());
+    return Number.isNaN(parsed) ? undefined : parsed;
+  } catch {
+    return undefined;
+  }
+}
+
 async function fetchAccountData(
   page: Page,
   startDate: Moment,
@@ -227,9 +244,11 @@ async function fetchAccountData(
   await searchByDates(page, startDate);
   await waitUntilElementDisappear(page, '.loading-bar-spinner');
   const txns = await getAccountTransactions(page, options);
+  const balance = await getCurrentBalance(page);
 
   return {
     accountNumber: accountID,
+    balance,
     txns,
   };
 }


### PR DESCRIPTION
## Summary

Populates `TransactionsAccount.balance` for Yahav accounts — previously always `undefined`, even though the field is declared on the shared type and set by leumi, hapoalim, discount, beinleumi-group, mizrahi, visa-cal, one-zero, and beyahad-bishvilha.

## What

Adds a `getCurrentBalance(page)` helper called from `fetchAccountData`. Yahav does not render a dedicated current-balance field on the statements page, so the helper reads the running-balance column of the newest transaction row — which equals the current account balance after that transaction posted.

Selector is purely structural (no locale-dependent text):

```
.transactions .list-item-holder .entire-content-ctr:first-of-type .col:last-child
```

Returns `undefined` if the element is missing or the value cannot be parsed, so callers treat balance as absent rather than receive a bad number.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npx jest src/scrapers/yahav.test.ts` passes (credential-gated tests remain skipped as usual)
- [x] Verified live against a real Yahav account — balance matches what the UI shows after the newest transaction