### PR TITLE
fix(isracard): handle 429 automation block gracefully

### DIFF
--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -73,8 +73,9 @@ export async function fetchGetWithinPage<TResult>(
       );
     }
   }, url);
-  if (result !== null && (status === 429 || result.includes('Block Automation'))) {
-    throw new Error('AutomationBlockedError: Provider blocked the headless request (429)');
+  if (result !== null && result.includes('Block Automation')) {
+    const errorBody = result.substring(0, 200);
+    throw new Error(`AutomationBlockedError: Provider blocked the headless request. url: ${url}, status: ${status}, body: ${errorBody}`);
   }
   if (result !== null) {
     try {
@@ -120,7 +121,8 @@ export async function fetchPostWithinPage<TResult>(
   );
 
   if (result !== null && result.includes('Block Automation')) {
-    throw new Error('AutomationBlockedError: Provider blocked the headless request (429)');
+    const errorBody = result.substring(0, 200);
+    throw new Error(`AutomationBlockedError: Provider blocked the headless request. url: ${url}, body: ${errorBody}`);
   }
   try {
     if (result !== null) {

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -73,6 +73,9 @@ export async function fetchGetWithinPage<TResult>(
       );
     }
   }, url);
+  if (result !== null && (status === 429 || result.includes('Block Automation'))) {
+    throw new Error('AutomationBlockedError: Provider blocked the headless request (429)');
+  }
   if (result !== null) {
     try {
       return JSON.parse(result);
@@ -116,6 +119,9 @@ export async function fetchPostWithinPage<TResult>(
     extraHeaders,
   );
 
+  if (result !== null && result.includes('Block Automation')) {
+    throw new Error('AutomationBlockedError: Provider blocked the headless request (429)');
+  }
   try {
     if (result !== null) {
       return JSON.parse(result);


### PR DESCRIPTION
*(Note: I debugged this issue and drafted this PR with the help of my AI pair programmers, Gemini and Codex, while working on a local finance project).*

### What changed
Currently, when Isracard blocks headless browsers, it returns a plain-text 429 response: `Block Automation`. The scraper tries to parse this as JSON, resulting in a fatal `Unexpected token 'B'` crash.

This PR intercepts the response text. If it contains the block message or a 429 status, it throws a structured `AutomationBlockedError` instead. 

### Why this matters
While this doesn't bypass the WAF (which I see is being handled in other PRs like #1064), it prevents a blind JSON parsing crash. It allows consumer applications to catch the error gracefully and prevents them from accidentally spamming the provider with retries.

Fixes #1098