### PR TITLE
fix(leumi): wait for SPA stabilization after hash change navigation

### DIFF
--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -18,6 +18,7 @@ const FILTERED_TRANSACTIONS_URL = `${BASE_URL}/ChannelWCF/Broker.svc/ProcessRequ
 const DATE_FORMAT = 'DD.MM.YY';
 const ACCOUNT_BLOCKED_MSG = 'המנוי חסום';
 const INVALID_PASSWORD_MSG = 'אחד או יותר מפרטי ההזדהות שמסרת שגויים. ניתן לנסות שוב';
+const ADVANCED_SEARCH_BUTTON_SELECTOR = 'button[title="חיפוש מתקדם"]';
 
 function getPossibleLoginResults() {
   const urls: LoginOptions['possibleResults'] = {
@@ -121,8 +122,8 @@ async function fetchTransactionsForAccount(
   // runtime for some accounts after 1-2 seconds so we need to hang the process for a short while.
   await hangProcess(4000);
 
-  await waitUntilElementFound(page, 'button[title="חיפוש מתקדם"]', true);
-  await clickButton(page, 'button[title="חיפוש מתקדם"]');
+  await waitUntilElementFound(page, ADVANCED_SEARCH_BUTTON_SELECTOR, true);
+  await clickButton(page, ADVANCED_SEARCH_BUTTON_SELECTOR);
   await waitUntilElementFound(page, 'bll-radio-button', true);
   await clickButton(page, 'bll-radio-button:not([checked])');
 
@@ -243,7 +244,7 @@ class LeumiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
     const startMoment = moment.max(minimumStartMoment, moment(startDate));
 
     await this.navigateTo(TRANSACTIONS_URL);
-    await waitUntilElementFound(this.page, 'button[title="חיפוש מתקדם"]', true);
+    await waitUntilElementFound(this.page, ADVANCED_SEARCH_BUTTON_SELECTOR, true);
 
     const accounts = await fetchTransactions(this.page, startMoment, this.options);
 

--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -243,6 +243,7 @@ class LeumiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
     const startMoment = moment.max(minimumStartMoment, moment(startDate));
 
     await this.navigateTo(TRANSACTIONS_URL);
+    await waitUntilElementFound(this.page, 'button[title="חיפוש מתקדם"]', true);
 
     const accounts = await fetchTransactions(this.page, startMoment, this.options);
 


### PR DESCRIPTION
*(Note: I tracked down this timeout bug and drafted this PR with the help of my AI pair programmers, Gemini and Codex).*

Closes #1100

### Description
This PR fixes the intermittent 60000ms generic timeout failures on Leumi (`Waiting for selector 'button[title="חיפוש מתקדם"]' failed`).

### The Bug
After a successful login, the scraper attempts to force the routing to the transactions page using `await this.navigateTo(TRANSACTIONS_URL)`. However, if the user was randomly routed to the account summary dashboard (`#/hpsummary`), this navigation is just a **hash change**. Puppeteer's `goto` resolves instantly for hash changes without waiting for the DOM. The scraper then immediately calls `fetchTransactions()` and begins waiting for the Advanced Search button before the SPA has actually fetched and rendered the transactions widget, leading to a timeout crash.

### The Fix
I added an explicit `await waitUntilElementFound(this.page, 'button[title="חיפוש מתקדם"]', true);` immediately after the `navigateTo` call in `fetchData()`. This guarantees the SPA has finished stabilizing and the transactions widget is fully painted before the scraper attempts to iterate over the accounts.