### PR TITLE
fix: remove redundant INITIALIZING progress emission

### DIFF
--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -101,7 +101,6 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
   async initialize() {
     await super.initialize();
     debug('initialize scraper');
-    this.emitProgress(ScraperProgressTypes.Initializing);
 
     const page = await this.initializePage();
     await page.setCacheEnabled(false); // Clear cache and avoid 300's response status


### PR DESCRIPTION
## Summary
- Removed redundant `INITIALIZING` progress emission in `BaseScraperWithBrowser.initialize()` that was causing duplicate log entries.
- The progress event is already emitted by the base class `BaseScraper.initialize()`.

## Test plan
- Manually verified by running the scraper and observing that the `INITIALIZING` log now appears only once.
- Verified that `npm run build` passes without errors.