### PR TITLE
feat(isracard): expose billing period data per account

### DIFF
--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -11,6 +11,7 @@ import { runSerial, sleep } from '../helpers/waiting';
 import {
   TransactionStatuses,
   TransactionTypes,
+  type BillingPeriod,
   type Transaction,
   type TransactionInstallments,
   type TransactionsAccount,
@@ -62,6 +63,8 @@ interface ScrapedAccount {
   index: number;
   accountNumber: string;
   processedDate: string;
+  period: string;
+  billingTotal: number;
 }
 
 interface ScrapedLoginValidation {
@@ -83,6 +86,8 @@ interface ScrapedAccountsWithinPageResponse {
       cardIndex: string;
       cardNumber: string;
       billingDate: string;
+      period: string;
+      billingSumSekel: string;
     }[];
   };
 }
@@ -130,6 +135,8 @@ async function fetchAccounts(page: Page, servicesUrl: string, monthMoment: Momen
           index: parseInt(cardCharge.cardIndex, 10),
           accountNumber: cardCharge.cardNumber,
           processedDate: moment(cardCharge.billingDate, DATE_FORMAT).toISOString(),
+          period: cardCharge.period,
+          billingTotal: parseFloat(cardCharge.billingSumSekel),
         };
       });
     }
@@ -198,6 +205,7 @@ function convertTransactions(
       identifier: parseInt(isOutbound ? txn.voucherNumberRatzOutbound : txn.voucherNumberRatz, 10),
       date: txnMoment.toISOString(),
       processedDate: currentProcessedDate,
+      billingDate: processedDate,
       originalAmount: isOutbound ? -txn.dealSumOutbound : -txn.dealSum,
       originalCurrency: convertCurrency(txn.currentPaymentCurrency ?? txn.currencyId),
       chargedAmount: isOutbound ? -txn.paymentSumOutbound : -txn.paymentSum,
@@ -231,18 +239,23 @@ async function fetchTransactions(
   if (dataResult && dataResult.Header?.Status === '1' && dataResult.CardsTransactionsListBean) {
     const accountTxns: ScrapedAccountsWithIndex = {};
     accounts.forEach(account => {
+      const billingPeriod: BillingPeriod = {
+        billingDate: account.processedDate,
+        status: account.period === 'Next' ? 'current' : 'previous',
+        total: account.billingTotal,
+      };
+
       const txnGroups: ScrapedCurrentCardTransactions[] | undefined =
         dataResult.CardsTransactionsListBean?.[`Index${account.index}`]?.CurrentCardTransactions;
+
+      let allTxns: Transaction[] = [];
       if (txnGroups) {
-        let allTxns: Transaction[] = [];
         txnGroups.forEach(txnGroup => {
           if (txnGroup.txnIsrael) {
-            const txns = convertTransactions(txnGroup.txnIsrael, account.processedDate, options);
-            allTxns.push(...txns);
+            allTxns.push(...convertTransactions(txnGroup.txnIsrael, account.processedDate, options));
           }
           if (txnGroup.txnAbroad) {
-            const txns = convertTransactions(txnGroup.txnAbroad, account.processedDate, options);
-            allTxns.push(...txns);
+            allTxns.push(...convertTransactions(txnGroup.txnAbroad, account.processedDate, options));
           }
         });
 
@@ -252,10 +265,17 @@ async function fetchTransactions(
         if (options.outputData?.enableTransactionsFilterByDate ?? true) {
           allTxns = filterOldTransactions(allTxns, startMoment, options.combineInstallments || false);
         }
+      }
+
+      if (accountTxns[account.accountNumber]) {
+        accountTxns[account.accountNumber].txns.push(...allTxns);
+        accountTxns[account.accountNumber].billingPeriods!.push(billingPeriod);
+      } else {
         accountTxns[account.accountNumber] = {
           accountNumber: account.accountNumber,
           index: account.index,
           txns: allTxns,
+          billingPeriods: [billingPeriod],
         };
       }
     });
@@ -357,23 +377,29 @@ async function fetchAllTransactions(
     allMonths,
   );
   const combinedTxns: Record<string, Transaction[]> = {};
+  const combinedBillingPeriods: Record<string, BillingPeriod[]> = {};
 
   finalResult.forEach(result => {
     Object.keys(result).forEach(accountNumber => {
-      let txnsForAccount = combinedTxns[accountNumber];
-      if (!txnsForAccount) {
-        txnsForAccount = [];
-        combinedTxns[accountNumber] = txnsForAccount;
+      if (!combinedTxns[accountNumber]) {
+        combinedTxns[accountNumber] = [];
       }
-      const toBeAddedTxns = result[accountNumber].txns;
-      combinedTxns[accountNumber].push(...toBeAddedTxns);
+      combinedTxns[accountNumber].push(...result[accountNumber].txns);
+
+      if (!combinedBillingPeriods[accountNumber]) {
+        combinedBillingPeriods[accountNumber] = [];
+      }
+      combinedBillingPeriods[accountNumber].push(...(result[accountNumber].billingPeriods ?? []));
     });
   });
 
-  const accounts = Object.keys(combinedTxns).map(accountNumber => {
+  const allAccountNumbers = new Set([...Object.keys(combinedTxns), ...Object.keys(combinedBillingPeriods)]);
+
+  const accounts = Array.from(allAccountNumbers).map(accountNumber => {
     return {
       accountNumber,
-      txns: combinedTxns[accountNumber],
+      txns: combinedTxns[accountNumber] ?? [],
+      billingPeriods: combinedBillingPeriods[accountNumber],
     };
   });
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,7 +1,18 @@
+export interface BillingPeriod {
+  /** ISO date string — the billing cycle closing date as returned by the bank */
+  billingDate: string;
+  /** 'previous' = closed/already debited from bank account; 'current' = open/still accumulating */
+  status: 'previous' | 'current';
+  /** Total amount charged in this billing period (in ILS), as reported directly by the bank API */
+  total: number;
+}
+
 export interface TransactionsAccount {
   accountNumber: string;
   balance?: number;
   txns: Transaction[];
+  /** All billing periods for this account, including the current open period even if it has no transactions */
+  billingPeriods?: BillingPeriod[];
 }
 
 export enum TransactionTypes {
@@ -40,6 +51,12 @@ export interface Transaction {
    * ISO date string
    */
   processedDate: string;
+  /**
+   * ISO date string — the billing cycle closing date this transaction belongs to.
+   * Unlike processedDate, this is never overridden by fullPaymentDate and always
+   * identifies the billing period the transaction was scraped under.
+   */
+  billingDate?: string;
   originalAmount: number;
   originalCurrency: string;
   chargedAmount: number;


### PR DESCRIPTION
## What

The Isracard API already returns billing period information alongside transactions — the billing closing date, whether the period is current or previous, and the total amount charged — but this data was previously discarded.

**New `BillingPeriod` interface** (`src/transactions.ts`):
```ts
export interface BillingPeriod {
  /** ISO date string — the billing cycle closing date as returned by the bank */
  billingDate: string;
  /** 'previous' = closed/already debited; 'current' = open/still accumulating */
  status: 'previous' | 'current';
  /** Total amount charged in this billing period (ILS), as reported by the bank API */
  total: number;
}
```

`TransactionsAccount` gets `billingPeriods?: BillingPeriod[]` — all billing periods including the current open one even with no transactions yet.

`Transaction` gets `billingDate?: string` — the billing cycle closing date, distinct from `processedDate` which can be overridden by `fullPaymentDate`.

## Why

Without this, consumers must guess billing cycle groupings from `processedDate`. The Isracard API returns this grouping explicitly — with totals and open/closed status per period. Exposing it makes accurate billing-cycle views possible without heuristics.

## Changes

- `src/transactions.ts` — new `BillingPeriod` type; `billingPeriods` on `TransactionsAccount`; `billingDate` on `Transaction`
- `src/scrapers/base-isracard-amex.ts` — reads `period` and `billingSumSekel` from the API response, builds `BillingPeriod` objects per account, merges them across multi-month fetches (same pattern as transactions)