### PR TITLE
fix(discount): add retail3 to successful login urls

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -147,6 +147,8 @@ function getPossibleLoginResults(): PossibleLoginResults {
     `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/`,
+    `${BASE_URL}/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`,
+    `${BASE_URL}/apollo/retail3/`,
   ];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];


### PR DESCRIPTION
This pull request adds support for a new version of the retail portal to the login results logic in the `discount.ts` scraper. The main change is the inclusion of `retail3` URLs to the list of possible login result destinations.

Enhancements to login result handling:

* Added support for `retail3` by including `${BASE_URL}/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE` and `${BASE_URL}/apollo/retail3/` to the list of valid login result URLs in the `getPossibleLoginResults` function.

Closes #1110