### PR TITLE
fix(discount): add retail3 to successful login urls

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -147,6 +147,8 @@ function getPossibleLoginResults(): PossibleLoginResults {
     `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/`,
+    `${BASE_URL}/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`,
+    `${BASE_URL}/apollo/retail3/`,
   ];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];


### PR DESCRIPTION
 * Discount Bank started redirecting to /apollo/retail3/ after login. Add both retail3 URL variants to match the existing retail/retail2 pattern.