### PR TITLE
fix(discount): recognize retail3 (and future retailN) post-login URL

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -143,11 +143,9 @@ async function navigateOrErrorLabel(page: Page) {
 
 function getPossibleLoginResults(): PossibleLoginResults {
   const urls: PossibleLoginResults = {};
-  urls[LoginResults.Success] = [
-    `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`,
-    `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`,
-    `${BASE_URL}/apollo/retail2/`,
-  ];
+  // Discount periodically bumps the post-login app path (retail, retail2, retail3, ...).
+  // Match any retailN variant so a new bump does not break login detection.
+  urls[LoginResults.Success] = [/\/apollo\/retail\d*\/(#\/MY_ACCOUNT_HOMEPAGE)?$/];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];
   return urls;


### PR DESCRIPTION
## Problem

Bank Discount migrated the post-login app path to `/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`. The scraper's success-URL list only matched `retail` and `retail2`, so login visibly succeeds in the browser (the bank shows "זוהיתם בהצלחה") but `getKeyByValue` finds no match and returns `UNKNOWN_ERROR`.

This currently breaks all Discount logins.

## Fix

Replace the hardcoded exact-string success URLs with a single regex that matches any `retailN` variant:

```ts
urls[LoginResults.Success] = [/\/apollo\/retail\d*\/(#\/MY_ACCOUNT_HOMEPAGE)?$/];
```

`PossibleLoginResults` already allows `RegExp` entries and `getKeyByValue` already handles them via `condition.test(value)`, so this is type-safe and needs no other changes. It also covers the bare `/apollo/retail2/` case that was previously listed, and future path bumps (`retail4`, ...) won't reintroduce the breakage.

## Testing

Verified against a live Discount account: login is now correctly detected as success and transactions sync. Reproduced the original `UNKNOWN_ERROR` beforehand and confirmed the post-login URL was `https://start.telebank.co.il/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`.