### PR TITLE
fix(discount): add retail3 to successful login urls

### DIFF
--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -147,6 +147,8 @@ function getPossibleLoginResults(): PossibleLoginResults {
     `${BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE`,
     `${BASE_URL}/apollo/retail2/`,
+    `${BASE_URL}/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`,
+    `${BASE_URL}/apollo/retail3/`,
   ];
   urls[LoginResults.InvalidPassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE`];
   urls[LoginResults.ChangePassword] = [`${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`];


### PR DESCRIPTION
After logging in i get routed to this url 
`https://start.telebank.co.il/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE`
Added the same paths as retail2 just to be extra safe

