### PR TITLE
fix(one-zero): bypass Cloudflare bot-detection with Android TLS fingerprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "debug": "^4.3.2",
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.37",
-        "puppeteer": "^24.40.0"
+        "puppeteer": "^24.40.0",
+        "undici": "^6.27.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.4.4",
@@ -8479,6 +8480,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "debug": "^4.3.2",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.37",
-    "puppeteer": "^24.40.0"
+    "puppeteer": "^24.40.0",
+    "undici": "^6.27.0"
   },
   "files": [
     "lib/**/*"

--- a/src/helpers/mobile-fetch.ts
+++ b/src/helpers/mobile-fetch.ts
@@ -1,0 +1,88 @@
+import { Agent, fetch as undiciFetch } from 'undici';
+
+/**
+ * Android OkHttp 4.x TLS cipher suite order.
+ * Node.js's built-in fetch uses a different TLS fingerprint (JA3) that Cloudflare
+ * bot-management blocks on some Israeli bank APIs (e.g. One Zero / tfd-bank.com).
+ * Using undici with this cipher order produces a fingerprint that matches the
+ * mobile apps these APIs were designed for.
+ */
+const ANDROID_CIPHERS = [
+  'TLS_AES_128_GCM_SHA256',
+  'TLS_AES_256_GCM_SHA384',
+  'TLS_CHACHA20_POLY1305_SHA256',
+  'ECDHE-ECDSA-AES128-GCM-SHA256',
+  'ECDHE-RSA-AES128-GCM-SHA256',
+  'ECDHE-ECDSA-AES256-GCM-SHA384',
+  'ECDHE-RSA-AES256-GCM-SHA384',
+  'ECDHE-ECDSA-CHACHA20-POLY1305',
+  'ECDHE-RSA-CHACHA20-POLY1305',
+  'ECDHE-RSA-AES128-SHA',
+  'ECDHE-RSA-AES256-SHA',
+  'AES128-GCM-SHA256',
+  'AES256-GCM-SHA384',
+  'AES128-SHA',
+  'AES256-SHA',
+].join(':');
+
+const ANDROID_SIGALGS = [
+  'ecdsa_secp256r1_sha256',
+  'rsa_pss_rsae_sha256',
+  'rsa_pkcs1_sha256',
+  'ecdsa_secp384r1_sha384',
+  'rsa_pss_rsae_sha384',
+  'rsa_pkcs1_sha384',
+  'rsa_pss_rsae_sha512',
+  'rsa_pkcs1_sha512',
+].join(':');
+
+const mobileAgent = new Agent({
+  connect: {
+    ciphers: ANDROID_CIPHERS,
+    sigalgs: ANDROID_SIGALGS,
+    minVersion: 'TLSv1.2',
+    maxVersion: 'TLSv1.3',
+  },
+});
+
+const MOBILE_HEADERS = {
+  'User-Agent': 'okhttp/4.10.0',
+  'Accept-Encoding': 'gzip',
+  Connection: 'Keep-Alive',
+};
+
+export async function mobileFetchPost<TResult = any>(
+  url: string,
+  data: Record<string, any>,
+  extraHeaders: Record<string, any> = {},
+): Promise<TResult> {
+  const response = await undiciFetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...MOBILE_HEADERS,
+      ...extraHeaders,
+    },
+    body: JSON.stringify(data),
+    dispatcher: mobileAgent,
+  });
+  return response.json() as Promise<TResult>;
+}
+
+export async function mobileFetchGraphql<TResult>(
+  url: string,
+  query: string,
+  variables: Record<string, unknown> = {},
+  extraHeaders: Record<string, any> = {},
+): Promise<TResult> {
+  const result = await mobileFetchPost<{ data: TResult; errors?: { message: string }[] }>(
+    url,
+    { operationName: null, query, variables },
+    extraHeaders,
+  );
+  if (result.errors?.length) {
+    throw new Error(result.errors[0].message);
+  }
+  return result.data;
+}

--- a/src/scrapers/one-zero.ts
+++ b/src/scrapers/one-zero.ts
@@ -1,6 +1,6 @@
 import moment from 'moment/moment';
 import { getDebug } from '../helpers/debug';
-import { fetchGraphql, fetchPost } from '../helpers/fetch';
+import { mobileFetchGraphql, mobileFetchPost } from '../helpers/mobile-fetch';
 import { getRawTransaction } from '../helpers/transactions';
 import {
   type Transaction as ScrapingTransaction,
@@ -81,7 +81,7 @@ type Movement = {
 
 type QueryPagination = { hasMore: boolean; cursor: string };
 
-const IDENTITY_SERVER_URL = 'https://identity.tfd-bank.com/v1/';
+const IDENTITY_SERVER_URL = 'https://identity.tfd-bank.com/v1';
 
 const GRAPHQL_API_URL = 'https://mobile.tfd-bank.com/mobile-graph/graphql';
 
@@ -108,7 +108,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Fetching device token');
-    const deviceTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/devices/token`, {
+    const deviceTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/devices/token`, {
       extClientId: 'mobile',
       os: 'Android',
     });
@@ -119,7 +119,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
 
     debug(`Sending OTP to phone number ${phoneNumber}`);
 
-    const otpPrepareResponse = await fetchPost(`${IDENTITY_SERVER_URL}/otp/prepare`, {
+    const otpPrepareResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/otp/prepare`, {
       factorValue: phoneNumber,
       deviceToken,
       otpChannel: 'SMS_OTP',
@@ -142,7 +142,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Requesting OTP token');
-    const otpVerifyResponse = await fetchPost(`${IDENTITY_SERVER_URL}/otp/verify`, {
+    const otpVerifyResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/otp/verify`, {
       otpContext: this.otpContext,
       otpCode,
     });
@@ -199,7 +199,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Requesting id token');
-    const getIdTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/getIdToken`, {
+    const getIdTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/getIdToken`, {
       otpSmsToken: otpTokenResult.longTermTwoFactorAuthToken,
       email: credentials.email,
       pass: credentials.password,
@@ -212,7 +212,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
 
     debug('Requesting session token');
 
-    const getSessionTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/sessions/token`, {
+    const getSessionTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/sessions/token`, {
       idToken,
       pass: credentials.password,
     });
@@ -239,7 +239,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
       debug(`Fetching transactions for account ${portfolio.portfolioNum}...`);
       const {
         movements: { movements: newMovements, pagination },
-      }: { movements: { movements: Movement[]; pagination: QueryPagination } } = await fetchGraphql(
+      }: { movements: { movements: Movement[]; pagination: QueryPagination } } = await mobileFetchGraphql(
         GRAPHQL_API_URL,
         GET_MOVEMENTS,
         {
@@ -330,7 +330,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     const startMoment = moment.max(defaultStartMoment, moment(startDate));
 
     debug('Fetching account list');
-    const result = await fetchGraphql<{ customer: Customer[] }>(
+    const result = await mobileFetchGraphql<{ customer: Customer[] }>(
       GRAPHQL_API_URL,
       GET_CUSTOMER,
       {},


### PR DESCRIPTION
## Problem

The One Zero scraper has been failing with HTTP 403 from Cloudflare's bot-management on `identity.tfd-bank.com`. The root cause is that Node.js's built-in `fetch` produces a **TLS JA3 fingerprint** that Cloudflare identifies as automated/non-mobile traffic and blocks — regardless of the HTTP headers sent.

Steps that fail without this fix:
1. `POST /v1/devices/token` → 403 (Cloudflare block page)
2. OTP is never sent → scraper exits with a generic error

## Solution

Add `src/helpers/mobile-fetch.ts` — a thin fetch wrapper using **undici** with the **Android OkHttp 4.x cipher-suite order**. This produces a TLS fingerprint that matches the One Zero mobile app and passes Cloudflare's bot check.

Switch all One Zero identity-server and GraphQL calls to the new `mobileFetchPost` / `mobileFetchGraphql` helpers. The rest of the codebase is unchanged.

**Also fixed:** a pre-existing double-slash bug — `IDENTITY_SERVER_URL` had a trailing slash and every path started with `/`, producing URLs like `/v1//devices/token`.

## Verification

Tested each step of the auth flow against the live API:

| Step | Endpoint | Before | After |
|---|---|---|---|
| 1 | `POST /v1/devices/token` | 403 Cloudflare | ✅ 200 + deviceToken |
| 2 | `POST /v1/otp/prepare` | blocked | ✅ 200 + otpContext |
| 3 | `POST /v1/otp/verify` | blocked | ✅ 200 + otpToken |
| 4 | `POST /v1/getIdToken` | blocked | ✅ 200 + idToken |
| 5 | `POST /v1/sessions/token` | blocked | ✅ 200 + accessToken |

## Changes

- **`src/helpers/mobile-fetch.ts`** *(new)* — undici-based fetch with Android OkHttp TLS profile
- **`src/scrapers/one-zero.ts`** — use `mobileFetchPost`/`mobileFetchGraphql`; fix `IDENTITY_SERVER_URL` double-slash
- **`package.json`** — add `undici` as a runtime dependency

`undici` is the official Node.js HTTP client (maintained by the Node.js core team) and is already the underlying implementation of the global `fetch` in Node 18+. Adding it as an explicit dependency to customise its TLS agent is the minimal-footprint approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)