### PR TITLE
feat(one-zero): fix Cloudflare TLS blocking and add opt-in credit card scraping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "debug": "^4.3.2",
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.37",
-        "puppeteer": "^24.40.0"
+        "puppeteer": "^24.40.0",
+        "undici": "^6.27.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.4.4",
@@ -8479,6 +8480,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "debug": "^4.3.2",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.37",
-    "puppeteer": "^24.40.0"
+    "puppeteer": "^24.40.0",
+    "undici": "^6.27.0"
   },
   "files": [
     "lib/**/*"

--- a/src/helpers/mobile-fetch.ts
+++ b/src/helpers/mobile-fetch.ts
@@ -1,0 +1,88 @@
+import { Agent, fetch as undiciFetch } from 'undici';
+
+/**
+ * Android OkHttp 4.x TLS cipher suite order.
+ * Node.js's built-in fetch uses a different TLS fingerprint (JA3) that Cloudflare
+ * bot-management blocks on some Israeli bank APIs (e.g. One Zero / tfd-bank.com).
+ * Using undici with this cipher order produces a fingerprint that matches the
+ * mobile apps these APIs were designed for.
+ */
+const ANDROID_CIPHERS = [
+  'TLS_AES_128_GCM_SHA256',
+  'TLS_AES_256_GCM_SHA384',
+  'TLS_CHACHA20_POLY1305_SHA256',
+  'ECDHE-ECDSA-AES128-GCM-SHA256',
+  'ECDHE-RSA-AES128-GCM-SHA256',
+  'ECDHE-ECDSA-AES256-GCM-SHA384',
+  'ECDHE-RSA-AES256-GCM-SHA384',
+  'ECDHE-ECDSA-CHACHA20-POLY1305',
+  'ECDHE-RSA-CHACHA20-POLY1305',
+  'ECDHE-RSA-AES128-SHA',
+  'ECDHE-RSA-AES256-SHA',
+  'AES128-GCM-SHA256',
+  'AES256-GCM-SHA384',
+  'AES128-SHA',
+  'AES256-SHA',
+].join(':');
+
+const ANDROID_SIGALGS = [
+  'ecdsa_secp256r1_sha256',
+  'rsa_pss_rsae_sha256',
+  'rsa_pkcs1_sha256',
+  'ecdsa_secp384r1_sha384',
+  'rsa_pss_rsae_sha384',
+  'rsa_pkcs1_sha384',
+  'rsa_pss_rsae_sha512',
+  'rsa_pkcs1_sha512',
+].join(':');
+
+const mobileAgent = new Agent({
+  connect: {
+    ciphers: ANDROID_CIPHERS,
+    sigalgs: ANDROID_SIGALGS,
+    minVersion: 'TLSv1.2',
+    maxVersion: 'TLSv1.3',
+  },
+});
+
+const MOBILE_HEADERS = {
+  'User-Agent': 'okhttp/4.10.0',
+  'Accept-Encoding': 'gzip',
+  Connection: 'Keep-Alive',
+};
+
+export async function mobileFetchPost<TResult = any>(
+  url: string,
+  data: Record<string, any>,
+  extraHeaders: Record<string, any> = {},
+): Promise<TResult> {
+  const response = await undiciFetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...MOBILE_HEADERS,
+      ...extraHeaders,
+    },
+    body: JSON.stringify(data),
+    dispatcher: mobileAgent,
+  });
+  return response.json() as Promise<TResult>;
+}
+
+export async function mobileFetchGraphql<TResult>(
+  url: string,
+  query: string,
+  variables: Record<string, unknown> = {},
+  extraHeaders: Record<string, any> = {},
+): Promise<TResult> {
+  const result = await mobileFetchPost<{ data: TResult; errors?: { message: string }[] }>(
+    url,
+    { operationName: null, query, variables },
+    extraHeaders,
+  );
+  if (result.errors?.length) {
+    throw new Error(result.errors[0].message);
+  }
+  return result.data;
+}

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -26,7 +26,8 @@ export type OptInFeatures =
   | 'isracard-amex:skipAdditionalTransactionInformation'
   | 'mizrahi:pendingIfNoIdentifier'
   | 'mizrahi:pendingIfHasGenericDescription'
-  | 'mizrahi:pendingIfTodayTransaction';
+  | 'mizrahi:pendingIfTodayTransaction'
+  | 'oneZero:includeCreditCards';
 
 export interface FutureDebit {
   amount: number;

--- a/src/scrapers/one-zero-queries.ts
+++ b/src/scrapers/one-zero-queries.ts
@@ -1,3 +1,42 @@
+export const GET_CARDS_DETAILS = `
+query GetCardsDetails($portfolioId: String!) {
+  cardsDetailsV3(portfolioId: $portfolioId) {
+    cardsDetails {
+      baseDetails {
+        cardId
+        lastFourDigits
+        cardType
+        cardStatus
+        currency
+        localFirstName
+        localLastName
+        provider
+      }
+    }
+  }
+}
+`;
+
+export const GET_CARD_ACTIVITY = `
+query GetCardActivity($cardId: String!, $billingYear: Int!, $billingMonth: Int!) {
+  cardActivityV3(cardId: $cardId, billingYear: $billingYear, billingMonth: $billingMonth) {
+    transactions {
+      transactionId
+      merchantName
+      purchaseDate
+      paymentDate
+      debitAmount { amount currency }
+      originalAmount { amount currency }
+      direction
+      status
+      type
+      numberOfPayments
+      paymentNumber
+    }
+  }
+}
+`;
+
 export const GET_CUSTOMER = `
 query GetCustomer {
   customer {

--- a/src/scrapers/one-zero.ts
+++ b/src/scrapers/one-zero.ts
@@ -1,6 +1,6 @@
 import moment from 'moment/moment';
 import { getDebug } from '../helpers/debug';
-import { fetchGraphql, fetchPost } from '../helpers/fetch';
+import { mobileFetchGraphql, mobileFetchPost } from '../helpers/mobile-fetch';
 import { getRawTransaction } from '../helpers/transactions';
 import {
   type Transaction as ScrapingTransaction,
@@ -81,7 +81,7 @@ type Movement = {
 
 type QueryPagination = { hasMore: boolean; cursor: string };
 
-const IDENTITY_SERVER_URL = 'https://identity.tfd-bank.com/v1/';
+const IDENTITY_SERVER_URL = 'https://identity.tfd-bank.com/v1';
 
 const GRAPHQL_API_URL = 'https://mobile.tfd-bank.com/mobile-graph/graphql';
 
@@ -108,7 +108,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Fetching device token');
-    const deviceTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/devices/token`, {
+    const deviceTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/devices/token`, {
       extClientId: 'mobile',
       os: 'Android',
     });
@@ -119,7 +119,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
 
     debug(`Sending OTP to phone number ${phoneNumber}`);
 
-    const otpPrepareResponse = await fetchPost(`${IDENTITY_SERVER_URL}/otp/prepare`, {
+    const otpPrepareResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/otp/prepare`, {
       factorValue: phoneNumber,
       deviceToken,
       otpChannel: 'SMS_OTP',
@@ -142,7 +142,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Requesting OTP token');
-    const otpVerifyResponse = await fetchPost(`${IDENTITY_SERVER_URL}/otp/verify`, {
+    const otpVerifyResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/otp/verify`, {
       otpContext: this.otpContext,
       otpCode,
     });
@@ -199,7 +199,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     }
 
     debug('Requesting id token');
-    const getIdTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/getIdToken`, {
+    const getIdTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/getIdToken`, {
       otpSmsToken: otpTokenResult.longTermTwoFactorAuthToken,
       email: credentials.email,
       pass: credentials.password,
@@ -212,7 +212,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
 
     debug('Requesting session token');
 
-    const getSessionTokenResponse = await fetchPost(`${IDENTITY_SERVER_URL}/sessions/token`, {
+    const getSessionTokenResponse = await mobileFetchPost(`${IDENTITY_SERVER_URL}/sessions/token`, {
       idToken,
       pass: credentials.password,
     });
@@ -239,7 +239,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
       debug(`Fetching transactions for account ${portfolio.portfolioNum}...`);
       const {
         movements: { movements: newMovements, pagination },
-      }: { movements: { movements: Movement[]; pagination: QueryPagination } } = await fetchGraphql(
+      }: { movements: { movements: Movement[]; pagination: QueryPagination } } = await mobileFetchGraphql(
         GRAPHQL_API_URL,
         GET_MOVEMENTS,
         {
@@ -330,7 +330,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     const startMoment = moment.max(defaultStartMoment, moment(startDate));
 
     debug('Fetching account list');
-    const result = await fetchGraphql<{ customer: Customer[] }>(
+    const result = await mobileFetchGraphql<{ customer: Customer[] }>(
       GRAPHQL_API_URL,
       GET_CUSTOMER,
       {},

--- a/src/scrapers/one-zero.ts
+++ b/src/scrapers/one-zero.ts
@@ -16,7 +16,7 @@ import {
   type ScraperScrapingResult,
   type ScraperTwoFactorAuthTriggerResult,
 } from './interface';
-import { GET_CUSTOMER, GET_MOVEMENTS } from './one-zero-queries';
+import { GET_CARD_ACTIVITY, GET_CARDS_DETAILS, GET_CUSTOMER, GET_MOVEMENTS } from './one-zero-queries';
 
 const HEBREW_WORDS_REGEX = /[\u0590-\u05FF][\u0590-\u05FF"'\-_ /\\]*[\u0590-\u05FF]/g;
 
@@ -80,6 +80,40 @@ type Movement = {
 };
 
 type QueryPagination = { hasMore: boolean; cursor: string };
+
+type CardAmount = {
+  amount: number;
+  currency: string;
+};
+
+type CardBaseDetails = {
+  cardId: string;
+  lastFourDigits: string;
+  cardType: string;
+  cardStatus: string;
+  currency: string;
+  localFirstName: string;
+  localLastName: string;
+  provider: string;
+};
+
+type CardDetail = {
+  baseDetails: CardBaseDetails;
+};
+
+type CardTransaction = {
+  transactionId: string;
+  merchantName: string;
+  purchaseDate: string;
+  paymentDate: string | null;
+  debitAmount: CardAmount | null;
+  originalAmount: CardAmount | null;
+  direction: string;
+  status: string;
+  type: string;
+  numberOfPayments: number | null;
+  paymentNumber: number | null;
+};
 
 const IDENTITY_SERVER_URL = 'https://identity.tfd-bank.com/v1';
 
@@ -292,6 +326,91 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     };
   }
 
+  private async fetchCreditCardAccounts(portfolioId: string, startDate: Date): Promise<TransactionsAccount[]> {
+    debug('Fetching credit cards list');
+    const cardsResult = await mobileFetchGraphql<{ cardsDetailsV3: { cardsDetails: CardDetail[] } }>(
+      GRAPHQL_API_URL,
+      GET_CARDS_DETAILS,
+      { portfolioId },
+      { authorization: `Bearer ${this.accessToken}` },
+    );
+
+    const cards = cardsResult.cardsDetailsV3.cardsDetails.filter(card => card.baseDetails.cardStatus === 'ACTIVE');
+
+    const accounts: TransactionsAccount[] = [];
+
+    for (const card of cards) {
+      const { cardId, lastFourDigits } = card.baseDetails;
+      const allTransactions: CardTransaction[] = [];
+
+      const now = new Date();
+      let year = now.getFullYear();
+      let month = now.getMonth() + 1;
+      const startYear = startDate.getFullYear();
+      const startMonth = startDate.getMonth() + 1;
+
+      while (year > startYear || (year === startYear && month >= startMonth)) {
+        debug(`Fetching card activity for *${lastFourDigits}, ${year}-${month}`);
+        try {
+          const activityResult = await mobileFetchGraphql<{
+            cardActivityV3: { transactions: CardTransaction[] };
+          }>(
+            GRAPHQL_API_URL,
+            GET_CARD_ACTIVITY,
+            { cardId, billingYear: year, billingMonth: month },
+            { authorization: `Bearer ${this.accessToken}` },
+          );
+          allTransactions.push(...activityResult.cardActivityV3.transactions);
+        } catch (e) {
+          debug(`Failed to fetch card activity for *${lastFourDigits}, ${year}-${month}: ${String(e)}`);
+        }
+        month -= 1;
+        if (month === 0) {
+          month = 12;
+          year -= 1;
+        }
+      }
+
+      const matchingTransactions = allTransactions
+        .filter(txn => new Date(txn.purchaseDate) >= startDate)
+        .sort((a, b) => new Date(a.purchaseDate).valueOf() - new Date(b.purchaseDate).valueOf());
+
+      accounts.push({
+        accountNumber: `card-${lastFourDigits}`,
+        txns: matchingTransactions.map((txn): ScrapingTransaction => {
+          const modifier = txn.direction === 'DEBIT' ? -1 : 1;
+          const isInstallment = (txn.numberOfPayments ?? 0) > 1;
+          const result: ScrapingTransaction = {
+            identifier: txn.transactionId,
+            date: txn.purchaseDate,
+            processedDate: txn.paymentDate ?? txn.purchaseDate,
+            chargedAmount: (txn.debitAmount?.amount ?? 0) * modifier,
+            chargedCurrency: txn.debitAmount?.currency ?? 'ILS',
+            originalAmount: (txn.originalAmount?.amount ?? 0) * modifier,
+            originalCurrency: txn.originalAmount?.currency ?? txn.debitAmount?.currency ?? 'ILS',
+            description: txn.merchantName,
+            status: txn.status === 'COMPLETED' ? TransactionStatuses.Completed : TransactionStatuses.Pending,
+            type: isInstallment ? TransactionTypes.Installments : TransactionTypes.Normal,
+            ...(isInstallment && {
+              installments: {
+                number: txn.paymentNumber ?? 1,
+                total: txn.numberOfPayments ?? 1,
+              },
+            }),
+          };
+
+          if (this.options?.includeRawTransaction) {
+            result.rawTransaction = getRawTransaction(txn);
+          }
+
+          return result;
+        }),
+      });
+    }
+
+    return accounts;
+  }
+
   /**
    * one zero hebrew strings are reversed with a unicode control character that forces display in LTR order
    * We need to remove the unicode control character, and then reverse hebrew substrings inside the string
@@ -338,11 +457,21 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     );
     const portfolios = result.customer.flatMap(customer => customer.portfolios || []);
 
+    const accounts = await Promise.all(
+      portfolios.map(portfolio => this.fetchPortfolioMovements(portfolio, startMoment.toDate())),
+    );
+
+    if (this.options.optInFeatures?.includes('oneZero:includeCreditCards')) {
+      debug('Fetching credit card transactions (opt-in)');
+      for (const portfolio of portfolios) {
+        const cardAccounts = await this.fetchCreditCardAccounts(portfolio.portfolioId, startMoment.toDate());
+        accounts.push(...cardAccounts);
+      }
+    }
+
     return {
       success: true,
-      accounts: await Promise.all(
-        portfolios.map(portfolio => this.fetchPortfolioMovements(portfolio, startMoment.toDate())),
-      ),
+      accounts,
     };
   }
 }

--- a/src/scrapers/one-zero.ts
+++ b/src/scrapers/one-zero.ts
@@ -340,7 +340,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
     const accounts: TransactionsAccount[] = [];
 
     for (const card of cards) {
-      const { cardId, lastFourDigits } = card.baseDetails;
+      const { cardId, lastFourDigits, localFirstName, localLastName } = card.baseDetails;
       const allTransactions: CardTransaction[] = [];
 
       const now = new Date();
@@ -376,7 +376,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
         .sort((a, b) => new Date(a.purchaseDate).valueOf() - new Date(b.purchaseDate).valueOf());
 
       accounts.push({
-        accountNumber: `card-${lastFourDigits}`,
+        accountNumber: `*${lastFourDigits} ${localFirstName} ${localLastName}`,
         txns: matchingTransactions.map((txn): ScrapingTransaction => {
           const modifier = txn.direction === 'DEBIT' ? -1 : 1;
           const isInstallment = (txn.numberOfPayments ?? 0) > 1;
@@ -389,7 +389,7 @@ export default class OneZeroScraper extends BaseScraper<ScraperSpecificCredentia
             originalAmount: (txn.originalAmount?.amount ?? 0) * modifier,
             originalCurrency: txn.originalAmount?.currency ?? txn.debitAmount?.currency ?? 'ILS',
             description: txn.merchantName,
-            status: txn.status === 'COMPLETED' ? TransactionStatuses.Completed : TransactionStatuses.Pending,
+            status: txn.status === 'BOOKED' ? TransactionStatuses.Completed : TransactionStatuses.Pending,
             type: isInstallment ? TransactionTypes.Installments : TransactionTypes.Normal,
             ...(isInstallment && {
               installments: {


### PR DESCRIPTION
## Summary

Two related changes for the One Zero scraper:

**1. Fix Cloudflare bot-detection (TLS fingerprint)**

One Zero's API is behind Cloudflare, which blocks Node.js's native `fetch` based on its TLS JA3 fingerprint. This adds a new helper `src/helpers/mobile-fetch.ts` that uses `undici` with an Android OkHttp 4.x cipher suite order, bypassing the block. All One Zero HTTP calls now go through this helper.

**2. Opt-in credit card transaction scraping**

Adds `oneZero:includeCreditCards` to `OptInFeatures`. When enabled, the scraper calls `cardsDetailsV3` to list all active credit cards in the portfolio, then `cardActivityV3` per card per billing month to collect individual transactions — returned as additional accounts named `*<last4digits> <cardholder name>` (e.g. `*1234 ישראל ישראלי`).

- Installment transactions are mapped with correct `installments.number` / `installments.total` metadata
- Foreign-currency transactions populate `originalAmount`/`originalCurrency` from `debitAmount` (ILS) and `originalAmount` (foreign) fields respectively
- The API uses `BOOKED` (not `COMPLETED`) for settled transactions; mapped correctly to `TransactionStatuses.Completed`

> **Note:** One Zero bank account movements include a monthly lump-sum settlement entry (חיוב ישראכארט) representing the same spending as the individual card transactions. Users who enable this opt-in should be aware of potential duplication.

## Usage

```ts
const scraper = createScraper({
  companyId: CompanyTypes.oneZero,
  startDate,
  optInFeatures: ['oneZero:includeCreditCards'],
});
```

## Changes

- `src/helpers/mobile-fetch.ts` — new helper with Android TLS cipher suite via `undici`
- `src/scrapers/one-zero.ts` — use `mobileFetchPost`/`mobileFetchGraphql`; add `fetchCreditCardAccounts()` method; check opt-in flag in `fetchData()`
- `src/scrapers/one-zero-queries.ts` — add `GET_CARDS_DETAILS` and `GET_CARD_ACTIVITY` queries
- `src/scrapers/interface.ts` — add `'oneZero:includeCreditCards'` to `OptInFeatures`

## Test plan

- [x] `npm run build` passes with no lint or type errors
- [x] One Zero bank account movements scrape successfully (previously returned 403)
- [x] Scraping with `optInFeatures: ['oneZero:includeCreditCards']` returns additional accounts per card
- [x] Settled transactions show `status: completed` (API returns `BOOKED`)
- [x] Installment transactions have `type: 'installments'` and correct `installments` metadata
- [x] Foreign-currency transactions have `originalAmount`/`originalCurrency` populated
- [x] Multiple cardholders on the same portfolio are distinguishable by account name

🤖 Generated with [Claude Code](https://claude.com/claude-code)