### PR TITLE
fix: redact credential values from fetchPostWithinPage parse errors

### DIFF
--- a/src/helpers/fetch.test.ts
+++ b/src/helpers/fetch.test.ts
@@ -1,0 +1,34 @@
+import { type Page } from 'puppeteer';
+import { fetchPostWithinPage } from './fetch';
+
+function createPageReturning(responseText: string): Page {
+  return {
+    evaluate: jest.fn().mockResolvedValue(responseText),
+  } as unknown as Page;
+}
+
+describe('fetchPostWithinPage', () => {
+  test('does not leak request body or header values when the response is not valid JSON', async () => {
+    const page = createPageReturning('<html>not json</html>');
+
+    let message: string | undefined;
+    try {
+      await fetchPostWithinPage(
+        page,
+        'https://bank.example/login',
+        { Sisma: 'superSecretPass', username: 'someUser' },
+        { Authorization: 'Bearer leakmetoken' },
+      );
+    } catch (e) {
+      message = (e as Error).message;
+    }
+
+    expect(message).toBeDefined();
+    // credential/secret values must never appear in the error message
+    expect(message).not.toContain('superSecretPass');
+    expect(message).not.toContain('leakmetoken');
+    // field names are kept for diagnostics
+    expect(message).toContain('Sisma');
+    expect(message).toContain('Authorization');
+  });
+});

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -123,7 +123,10 @@ export async function fetchPostWithinPage<TResult>(
   } catch (e) {
     if (!ignoreErrors) {
       throw new Error(
-        `fetchPostWithinPage parse error: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}, url: ${url}, data: ${JSON.stringify(data)}, extraHeaders: ${JSON.stringify(extraHeaders)}, result: ${result}`,
+        // Only log the field names, never their values: request bodies/headers can contain
+        // credentials (e.g. passwords, auth tokens). `result` is the institute's response body
+        // (not user credentials) and is kept as the primary diagnostic for the parse failure.
+        `fetchPostWithinPage parse error: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}, url: ${url}, data: ${JSON.stringify(Object.keys(data ?? {}))}, extraHeaders: ${JSON.stringify(Object.keys(extraHeaders ?? {}))}, result: ${result}`,
       );
     }
   }


### PR DESCRIPTION
## Problem

When the institute server returns a non-JSON body on a POST, `fetchPostWithinPage` throws a parse error that embedded the **full request body and headers** via `JSON.stringify(data)` / `JSON.stringify(extraHeaders)`.

For login requests these carry credentials — e.g. the isracard/amex login body includes `Sisma` (the user's password), and auth tokens travel in headers. The thrown error propagates up to the scrape result's `errorMessage` (`createGenericError((e as Error).message)` in `base-scraper.ts`), so a **plaintext password could surface in `errorMessage` and in any logs a consumer records** — particularly dangerous for tools running this in CI/cloud.

## Fix

Log only the **field names** (`Object.keys`) of `data` and `extraHeaders`, never their values. This preserves the diagnostic of *which* fields were sent without leaking any secret.

`result` (the institute's response body, not user credentials) is kept as the primary diagnostic for the parse failure.

```diff
-        data: ${JSON.stringify(data)}, extraHeaders: ${JSON.stringify(extraHeaders)}, result: ${result}`,
+        data: ${JSON.stringify(Object.keys(data ?? {}))}, extraHeaders: ${JSON.stringify(Object.keys(extraHeaders ?? {}))}, result: ${result}`,
```

## Test

Adds a regression test asserting that secret values (`Sisma` password, `Authorization` token) never appear in the error message, while field names are preserved for diagnostics.

## Scope

Only `fetchPostWithinPage` carried this leak. The sibling `fetchGetWithinPage` has no request body and logs only `url`/`result`/`status`; the node-side `fetchPost`/`fetchGraphql` do not stringify the body into errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
