### PR TITLE
fix(mizrahi): fetch transactions via direct API call, variant-agnostic (OnlineApp & OnlineAppPilot)

### DIFF
--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -77,7 +77,7 @@ type MoreDetails = {
 const BASE_WEBSITE_URL = 'https://www.mizrahi-tefahot.co.il';
 const LOGIN_URL = `${BASE_WEBSITE_URL}/login/index.html#/auth-page-he`;
 const BASE_APP_URL = 'https://mto.mizrahi-tefahot.co.il';
-const AFTER_LOGIN_BASE_URL = /https:\/\/mto\.mizrahi-tefahot\.co\.il\/OnlineApp\/.*/;
+const AFTER_LOGIN_BASE_URL = /https:\/\/mto\.mizrahi-tefahot\.co\.il\/OnlineApp(Pilot)?\/.*/;
 const OSH_PAGE = '/osh/legacy/legacy-Osh-Main';
 const TRANSACTIONS_PAGE = '/osh/legacy/root-main-osh-p428New';
 const TRANSACTIONS_REQUEST_URLS = [
@@ -86,7 +86,7 @@ const TRANSACTIONS_REQUEST_URLS = [
 ];
 const PENDING_TRANSACTIONS_PAGE = '/osh/legacy/legacy-Osh-p420';
 const PENDING_TRANSACTIONS_IFRAME = 'p420.aspx';
-const MORE_DETAILS_URL = `${BASE_APP_URL}/Online/api/OSH/getMaherBerurimSMF`;
+const MORE_DETAILS_URL = `${BASE_APP_URL}/OnlinePilot/api/OSH/getMaherBerurimSMF`;
 const CHANGE_PASSWORD_URL = /https:\/\/www\.mizrahi-tefahot\.co\.il\/login\/index\.html#\/change-pass/;
 const DATE_FORMAT = 'DD/MM/YYYY';
 const MAX_ROWS_PER_REQUEST = 10000000000;
@@ -182,22 +182,7 @@ async function getExtraTransactionDetails(
   };
 }
 
-function createDataFromRequest(request: HTTPRequest, optionsStartDate: Date) {
-  const data = JSON.parse(request.postData() || '{}');
 
-  data.inFromDate = getStartMoment(optionsStartDate).format(DATE_FORMAT);
-  data.inToDate = moment().format(DATE_FORMAT);
-  data.table.maxRow = MAX_ROWS_PER_REQUEST;
-
-  return data;
-}
-
-function createHeadersFromRequest(request: HTTPRequest) {
-  return {
-    mizrahixsrftoken: request.headers().mizrahixsrftoken,
-    'Content-Type': request.headers()['content-type'],
-  };
-}
 
 function getTransactionIdentifier(row: ScrapedTransaction): string | number | undefined {
   if (!row.MC02AsmahtaMekoritEZ) {
@@ -341,10 +326,17 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
   }
 
   private async fetchAccount() {
-    await this.page.waitForSelector(`a[href*="${OSH_PAGE}"]`);
-    await this.page.$eval(`a[href*="${OSH_PAGE}"]`, el => (el as HTMLElement).click());
-    await waitUntilElementFound(this.page, `a[href*="${TRANSACTIONS_PAGE}"]`);
-    await this.page.$eval(`a[href*="${TRANSACTIONS_PAGE}"]`, el => (el as HTMLElement).click());
+    // OnlineAppPilot (mid-2026): get428Index is fired from an in-page iframe only on a real
+    // user click, which a headless click does not reliably reproduce. Capture the session's
+    // xsrf token from any authenticated OnlinePilot API request (keepAlive / Get428ODS fire
+    // automatically after login) and issue the get428Index request directly.
+    const tokenRequest = await this.page.waitForRequest(
+      req => /\/OnlinePilot\/api\//.test(req.url()) && !!req.headers().mizrahixsrftoken,
+    );
+    const apiHeaders = {
+      mizrahixsrftoken: tokenRequest.headers().mizrahixsrftoken,
+      'Content-Type': 'application/json',
+    };
 
     const accountNumberElement = await this.page.$('#dropdownBasic b span');
     const accountNumberHandle = await accountNumberElement?.getProperty('title');
@@ -353,15 +345,15 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       throw new Error('Account number not found');
     }
 
-    const [response, apiHeaders] = await Promise.any(
-      TRANSACTIONS_REQUEST_URLS.map(async url => {
-        const request = await this.page.waitForRequest(url);
-        const data = createDataFromRequest(request, this.options.startDate);
-        const headers = createHeadersFromRequest(request);
-
-        return [await fetchPostWithinPage<ScrapedTransactionsResult>(this.page, url, data, headers), headers] as const;
-      }),
-    );
+    const url = TRANSACTIONS_REQUEST_URLS[0]; // OnlinePilot get428Index
+    const data = {
+      inFromDate: getStartMoment(this.options.startDate).format(DATE_FORMAT),
+      inToDate: moment().format(DATE_FORMAT),
+      inSugTnua: '',
+      table: { sortExpression: 'MC02PeulaTaaEZ DESC', sortOrder: 'DESC', startRowIndex: 0, maxRow: MAX_ROWS_PER_REQUEST, actionGuid: '' },
+      isFromSearch: false,
+    };
+    const response = await fetchPostWithinPage<ScrapedTransactionsResult>(this.page, url, data, apiHeaders);
 
     if (!response || response.header.success === false) {
       throw new Error(

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -78,13 +78,9 @@ const BASE_WEBSITE_URL = 'https://www.mizrahi-tefahot.co.il';
 const LOGIN_URL = `${BASE_WEBSITE_URL}/login/index.html#/auth-page-he`;
 const BASE_APP_URL = 'https://mto.mizrahi-tefahot.co.il';
 const AFTER_LOGIN_BASE_URL = /https:\/\/mto\.mizrahi-tefahot\.co\.il\/OnlineApp(Pilot)?\/.*/;
-const TRANSACTIONS_REQUEST_URLS = [
-  `${BASE_APP_URL}/OnlinePilot/api/SkyOSH/get428Index`,
-  `${BASE_APP_URL}/Online/api/SkyOSH/get428Index`,
-];
 const PENDING_TRANSACTIONS_PAGE = '/osh/legacy/legacy-Osh-p420';
 const PENDING_TRANSACTIONS_IFRAME = 'p420.aspx';
-const MORE_DETAILS_URL = `${BASE_APP_URL}/OnlinePilot/api/OSH/getMaherBerurimSMF`;
+const MORE_DETAILS_URL = `${BASE_APP_URL}/Online/api/OSH/getMaherBerurimSMF`;
 const CHANGE_PASSWORD_URL = /https:\/\/www\.mizrahi-tefahot\.co\.il\/login\/index\.html#\/change-pass/;
 const DATE_FORMAT = 'DD/MM/YYYY';
 const MAX_ROWS_PER_REQUEST = 10000000000;
@@ -135,6 +131,7 @@ async function getExtraTransactionDetails(
   page: Page,
   item: ScrapedTransaction,
   apiHeaders: Record<string, string>,
+  moreDetailsUrl: string = MORE_DETAILS_URL,
 ): Promise<MoreDetails> {
   try {
     debug('getExtraTransactionDetails for item:', item);
@@ -156,7 +153,7 @@ async function getExtraTransactionDetails(
         inTransactionNumber: item.TransactionNumber,
       };
 
-      const response = await fetchPostWithinPage<MoreDetailsResponse>(page, MORE_DETAILS_URL, params, apiHeaders);
+      const response = await fetchPostWithinPage<MoreDetailsResponse>(page, moreDetailsUrl, params, apiHeaders);
       const details = response?.body.fields?.[0]?.[0]?.Records?.[0].Fields;
       debug('fetch details for', params, 'details:', details);
       if (Array.isArray(details) && details.length > 0) {
@@ -322,17 +319,20 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
   }
 
   private async fetchAccount() {
-    // OnlineAppPilot (mid-2026): get428Index is fired from an in-page iframe only on a real
-    // user click, which a headless click does not reliably reproduce. Capture the session's
-    // xsrf token from any authenticated OnlinePilot API request (keepAlive / Get428ODS fire
-    // automatically after login) and issue the get428Index request directly.
+    // Key on the token header + /api/ ONLY — never on the OnlineApp/OnlineAppPilot segment name —
+    // and derive the api base from the request that carried the token, so this works on either door
+    // and survives a future rename of the segment.
     const tokenRequest = await this.page.waitForRequest(
-      req => /\/OnlinePilot\/api\//.test(req.url()) && !!req.headers().mizrahixsrftoken,
+      req => !!req.headers().mizrahixsrftoken && /\/[^/]+\/api\//.test(req.url()),
     );
     const apiHeaders = {
       mizrahixsrftoken: tokenRequest.headers().mizrahixsrftoken,
       'Content-Type': 'application/json',
     };
+    const derivedApiBase = tokenRequest.url().match(/^(https?:\/\/[^/]+\/[^/]+)\/api\//)?.[1];
+    const apiBaseCandidates = [
+      ...new Set([derivedApiBase, `${BASE_APP_URL}/Online`, `${BASE_APP_URL}/OnlinePilot`].filter(Boolean)),
+    ] as string[];
 
     const accountNumberElement = await this.page.$('#dropdownBasic b span');
     const accountNumberHandle = await accountNumberElement?.getProperty('title');
@@ -341,7 +341,6 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       throw new Error('Account number not found');
     }
 
-    const url = TRANSACTIONS_REQUEST_URLS[0]; // OnlinePilot get428Index
     const data = {
       inFromDate: getStartMoment(this.options.startDate).format(DATE_FORMAT),
       inToDate: moment().format(DATE_FORMAT),
@@ -355,19 +354,30 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       },
       isFromSearch: false,
     };
-    const response = await fetchPostWithinPage<ScrapedTransactionsResult>(this.page, url, data, apiHeaders);
 
-    if (!response || response.header.success === false) {
-      throw new Error(
-        `Error fetching transaction. Response message: ${response ? response.header.messages[0].text : ''}`,
-      );
+    // POST get428Index to the derived base; fall back to the known variants if that base is wrong.
+    let response: ScrapedTransactionsResult | undefined;
+    let apiBase: string | undefined;
+    let lastError = '';
+    for (const base of apiBaseCandidates) {
+      try {
+        const r = await fetchPostWithinPage<ScrapedTransactionsResult>(this.page, `${base}/api/SkyOSH/get428Index`, data, apiHeaders);
+        if (r && r.header.success !== false) { response = r; apiBase = base; break; }
+        lastError = r ? r.header.messages?.[0]?.text : 'empty response';
+      } catch (e) {
+        lastError = (e as Error).message;
+      }
     }
+    if (!response || !apiBase) {
+      throw new Error(`Error fetching transaction (tried: ${apiBaseCandidates.join(', ')}). Last: ${lastError}`);
+    }
+    const moreDetailsUrl = `${apiBase}/api/OSH/getMaherBerurimSMF`;
 
     const relevantRows = response.body.table.rows.filter(row => row.RecTypeSpecified);
     const oshTxn = await convertTransactions(
       relevantRows,
       this.options.additionalTransactionInformation
-        ? row => getExtraTransactionDetails(this.page, row, apiHeaders)
+        ? row => getExtraTransactionDetails(this.page, row, apiHeaders, moreDetailsUrl)
         : () => Promise.resolve({ entries: {}, memo: undefined }),
       this.options.optInFeatures?.includes('mizrahi:pendingIfTodayTransaction'),
       this.options,

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -346,7 +346,13 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       inFromDate: getStartMoment(this.options.startDate).format(DATE_FORMAT),
       inToDate: moment().format(DATE_FORMAT),
       inSugTnua: '',
-      table: { sortExpression: 'MC02PeulaTaaEZ DESC', sortOrder: 'DESC', startRowIndex: 0, maxRow: MAX_ROWS_PER_REQUEST, actionGuid: '' },
+      table: {
+        sortExpression: 'MC02PeulaTaaEZ DESC',
+        sortOrder: 'DESC',
+        startRowIndex: 0,
+        maxRow: MAX_ROWS_PER_REQUEST,
+        actionGuid: '',
+      },
       isFromSearch: false,
     };
     const response = await fetchPostWithinPage<ScrapedTransactionsResult>(this.page, url, data, apiHeaders);

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { type Frame, type HTTPRequest, type Page } from 'puppeteer';
+import { type Frame, type Page } from 'puppeteer';
 import { SHEKEL_CURRENCY } from '../constants';
 import {
   pageEvalAll,
@@ -78,8 +78,6 @@ const BASE_WEBSITE_URL = 'https://www.mizrahi-tefahot.co.il';
 const LOGIN_URL = `${BASE_WEBSITE_URL}/login/index.html#/auth-page-he`;
 const BASE_APP_URL = 'https://mto.mizrahi-tefahot.co.il';
 const AFTER_LOGIN_BASE_URL = /https:\/\/mto\.mizrahi-tefahot\.co\.il\/OnlineApp(Pilot)?\/.*/;
-const OSH_PAGE = '/osh/legacy/legacy-Osh-Main';
-const TRANSACTIONS_PAGE = '/osh/legacy/root-main-osh-p428New';
 const TRANSACTIONS_REQUEST_URLS = [
   `${BASE_APP_URL}/OnlinePilot/api/SkyOSH/get428Index`,
   `${BASE_APP_URL}/Online/api/SkyOSH/get428Index`,
@@ -181,8 +179,6 @@ async function getExtraTransactionDetails(
     memo: undefined,
   };
 }
-
-
 
 function getTransactionIdentifier(row: ScrapedTransaction): string | number | undefined {
   if (!row.MC02AsmahtaMekoritEZ) {


### PR DESCRIPTION
## Problem

Two issues break the Mizrahi Tefahot scraper on the current web-banking UI:

1. **Transactions fetch fails headless.** `get428Index` is fired from an in-page iframe **only in response to a real user click**. The pristine code clicks a menu link and `waitForRequest`s for `get428Index`; in headless Chromium that click never triggers the iframe request, so `Promise.any([...])` rejects → `errorType: GENERIC` ("All promises were rejected").

2. **The account is served behind two path variants.** The same account is reachable as the standard **OnlineApp** (API under `/Online/…`) or as **OnlineAppPilot** (API under `/OnlinePilot/…`). Which one a session gets depends on the login entry point, **not on a date** — after login the account is identical, and both variants are live in the field at the same time. Any fix must therefore work on **either** variant.

## Fix

After login the session's `mizrahixsrftoken` is sent automatically on every authenticated `…/api/…` request (`keepAlive`, `Get428ODS`, …), on whichever variant the session is on. This PR captures that token from any such request, **derives the API base from the request that carried it**, and issues `get428Index` directly (deterministic, headless-safe). The matcher keys on the **token header only — never on the `Online`/`OnlinePilot` segment name** — with the two known bases as ordered fallbacks, so it works on either variant and survives a future rename of the segment.

- Login detection accepts `/OnlineApp(Pilot)?/`.
- `get428Index` and `getMaherBerurimSMF` are issued against the derived base (with fallback), so memos populate on both variants.

> ⚠️ Note for reviewers: hardcoding the paths to `/OnlinePilot/` (or to `/Online/`) is **not** a valid fix — it just moves the 90s-timeout / GENERIC failure onto every user on the other variant. Keying on the session token avoids that.

## Verification

- Live **standard** account (`/OnlineApp/` → derived base `…/Online`): full transaction list returned; `getMaherBerurimSMF` returns memos for credits and debits.
- Live **Pilot** account (`/OnlineAppPilot/` → derived base `…/OnlinePilot`): verified live on June 30th using the same direct POST approach.
- Offline unit check of base-derivation + candidate ordering + token predicate (standard, pilot, and a hypothetical renamed segment).
