### PR TITLE
feat(visa-cal): OTP quick-login to expose all ID-linked cards (PayBox, Diners, co-branded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ const credentials = {
 ```
 This scraper supports fetching transaction from up to one year.
 
+### OTP (quick-login) mode
+Cal's "quick login" (כניסה מהירה), keyed on the national ID, returns **all** cards linked
+to it — including PayBox, Diners and other co-branded cards that username login hides. Pass
+an `otpCodeRetriever` callback instead of a password:
+```node
+const credentials = {
+  id: <national ID>,
+  last4Digits: <last 4 digits of any card on the account>,
+  otpCodeRetriever: async () => '123456', // return the SMS code once it arrives
+};
+```
+
 ## Max scraper (Formerly Leumi-Card)
 This scraper expects the following credentials object:
 ```node

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -54,7 +54,7 @@ export const SCRAPERS = {
   },
   [CompanyTypes.visaCal]: {
     name: 'Visa Cal',
-    loginFields: ['username', PASSWORD_FIELD],
+    loginFields: ['username', PASSWORD_FIELD, 'id', 'last4Digits', 'otpCodeRetriever'],
   },
   [CompanyTypes.isracard]: {
     name: 'Isracard',

--- a/src/scrapers/interface.ts
+++ b/src/scrapers/interface.ts
@@ -12,6 +12,7 @@ export type ScraperCredentials =
   | { id: string; password: string; num: string }
   | { id: string; password: string; card6Digits: string }
   | { username: string; nationalID: string; password: string }
+  | { id: string; last4Digits: string; otpCodeRetriever: () => Promise<string> }
   | ({ email: string; password: string } & (
       | {
           otpCodeRetriever: () => Promise<string>;

--- a/src/scrapers/visa-cal.test.ts
+++ b/src/scrapers/visa-cal.test.ts
@@ -17,6 +17,12 @@ describe('VisaCal legacy scraper', () => {
     expect(SCRAPERS.visaCal.loginFields).toContain('password');
   });
 
+  test('should expose OTP (quick-login) fields in scrapers constant', () => {
+    expect(SCRAPERS.visaCal.loginFields).toContain('id');
+    expect(SCRAPERS.visaCal.loginFields).toContain('last4Digits');
+    expect(SCRAPERS.visaCal.loginFields).toContain('otpCodeRetriever');
+  });
+
   maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
     'should fail on invalid user/password"',
     async () => {

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -1,7 +1,13 @@
 import moment from 'moment';
 import { type HTTPRequest, type Frame, type Page } from 'puppeteer';
 import { getDebug } from '../helpers/debug';
-import { clickButton, elementPresentOnPage, pageEval, waitUntilElementFound } from '../helpers/elements-interactions';
+import {
+  clickButton,
+  elementPresentOnPage,
+  fillInput,
+  pageEval,
+  waitUntilElementFound,
+} from '../helpers/elements-interactions';
 import { fetchPost } from '../helpers/fetch';
 import { getCurrentUrl, waitForNavigation } from '../helpers/navigation';
 import { getFromSessionStorage } from '../helpers/storage';
@@ -313,12 +319,25 @@ function getPossibleLoginResults() {
   return urls;
 }
 
-function createLoginFields(credentials: ScraperSpecificCredentials) {
+function createLoginFields(credentials: PasswordCredentials) {
   debug('create login fields for username and password');
   return [
     { selector: '[formcontrolname="userName"]', value: credentials.username },
     { selector: '[formcontrolname="password"]', value: credentials.password },
   ];
+}
+
+// The OTP form's buttons have no stable id/selector, so match on their text.
+async function clickButtonByText(frame: Frame, matcher: RegExp): Promise<boolean> {
+  return frame.evaluate((source: string) => {
+    const re = new RegExp(source);
+    const button = Array.from(document.querySelectorAll('button')).find(el => re.test(el.textContent || ''));
+    if (button) {
+      (button as HTMLElement).click();
+      return true;
+    }
+    return false;
+  }, matcher.source);
 }
 
 function convertParsedDataToTransactions(
@@ -382,29 +401,40 @@ function convertParsedDataToTransactions(
   });
 }
 
-type ScraperSpecificCredentials = { username: string; password: string };
+type PasswordCredentials = { username: string; password: string };
+
+// OTP ("quick login") credentials: national ID + last 4 digits of any card + an SMS code.
+// Unlike username/password, this exposes ALL cards linked to the ID (PayBox, Diners, etc.).
+type OtpCredentials = { id: string; last4Digits: string; otpCodeRetriever: () => Promise<string> };
+
+type ScraperSpecificCredentials = PasswordCredentials | OtpCredentials;
+
+function isOtpCredentials(credentials: ScraperSpecificCredentials): credentials is OtpCredentials {
+  return 'otpCodeRetriever' in credentials;
+}
 
 class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
   private authorization: string | undefined = undefined;
 
   private authRequestPromise: Promise<HTTPRequest | undefined> | undefined;
 
-  openLoginPopup = async () => {
+  // Open the login popup and switch to a tab: `#regular-login` (password) or `#send-otp` (OTP).
+  private openLoginTab = async (tabSelector: string, readySelector: string): Promise<Frame> => {
     debug('open login popup, wait until login button available');
     await waitUntilElementFound(this.page, '#ccLoginDesktopBtn', true);
     debug('click on the login button');
     await clickButton(this.page, '#ccLoginDesktopBtn');
-    debug('get the frame that holds the login');
     const frame = await getLoginFrame(this.page);
-    debug('wait until the password login tab header is available');
-    await waitUntilElementFound(frame, '#regular-login');
-    debug('navigate to the password login tab');
-    await clickButton(frame, '#regular-login');
-    debug('wait until the password login tab is active');
-    await waitUntilElementFound(frame, 'regular-login');
-
+    debug(`navigate to the ${tabSelector} login tab`);
+    await waitUntilElementFound(frame, tabSelector);
+    await clickButton(frame, tabSelector);
+    await waitUntilElementFound(frame, readySelector);
     return frame;
   };
+
+  openLoginPopup = () => this.openLoginTab('#regular-login', 'regular-login');
+
+  openOtpLoginPopup = () => this.openLoginTab('#send-otp', '[formcontrolname="id"]');
 
   async getCards() {
     const initData = await waitUntil(
@@ -451,6 +481,18 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     return Promise.resolve('09031987-273E-2311-906C-8AF85B17C8D9');
   }
 
+  // OTP flow: request an SMS code, wait for the caller to supply it, then enter + submit.
+  private async submitOtp(otpCodeRetriever: () => Promise<string>): Promise<void> {
+    const frame = await getLoginFrame(this.page);
+    if (!(await clickButtonByText(frame, /שלחו לי סיסמה/))) {
+      throw new Error('could not find the "send OTP via SMS" button');
+    }
+    await fillInput(frame, '[formcontrolname="otp"]', await otpCodeRetriever());
+    if (!(await clickButtonByText(frame, /כניסה|אישור|המשך/))) {
+      throw new Error('could not find the OTP submit button');
+    }
+  }
+
   getLoginOptions(credentials: ScraperSpecificCredentials): LoginOptions {
     this.authRequestPromise = this.page
       .waitForRequest(SSO_AUTHORIZATION_REQUEST_ENDPOINT, { timeout: 10_000 })
@@ -460,11 +502,18 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       });
     return {
       loginUrl: `${LOGIN_URL}`,
-      fields: createLoginFields(credentials),
-      submitButtonSelector: 'button[type="submit"]',
+      fields: isOtpCredentials(credentials)
+        ? [
+            { selector: '[formcontrolname="id"]', value: credentials.id },
+            { selector: '[formcontrolname="secondOtpParam"]', value: credentials.last4Digits },
+          ]
+        : createLoginFields(credentials),
+      submitButtonSelector: isOtpCredentials(credentials)
+        ? () => this.submitOtp(credentials.otpCodeRetriever)
+        : 'button[type="submit"]',
       possibleResults: getPossibleLoginResults(),
       checkReadiness: async () => waitUntilElementFound(this.page, '#ccLoginDesktopBtn'),
-      preAction: this.openLoginPopup,
+      preAction: isOtpCredentials(credentials) ? this.openOtpLoginPopup : this.openLoginPopup,
       postAction: async () => {
         try {
           await waitForNavigation(this.page);


### PR DESCRIPTION
**Problem:** The Visa Cal scraper only supports username/password login, which returns only the cards tied to that username. Cards linked to the same account under a different product — PayBox, Diners, co-branded — are invisible, even though they appear in Cal's web/app.

**Cause:** Cal binds card scope to the login *type*. The "quick login" (כניסה מהירה), keyed on the national ID, returns every card linked to the ID; username/password does not.

**Change:** Adds an OTP credential variant `{ id, last4Digits, otpCodeRetriever }` alongside `{ username, password }`. `VisaCalScraper` auto-selects the flow (it opens the `#send-otp` tab, fills ID + card last-4, requests an SMS code, awaits the caller's `otpCodeRetriever`, then enters + submits it). Reuses the existing SSO-token capture and post-login handling.

Also: registers the new fields in `SCRAPERS.visaCal.loginFields` and the `ScraperCredentials` union, documents the mode in the README, and adds a `loginFields` unit test.

**Usage:**
```js
const credentials = {
  id: '<national ID>',
  last4Digits: '<last 4 of any card on the account>',
  otpCodeRetriever: async () => '123456', // return the SMS code once it arrives
};
```

**Testing:** Validated against a live Cal account — the OTP flow surfaces the previously-missing cards (e.g. PayBox) and fetches their transactions. `type-check`, `lint`, and unit tests pass. Password login is unchanged.
