### PR TITLE
fix(isracard): workaround for bot detection

### DIFF
--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -6,6 +6,14 @@ export async function maskHeadlessUserAgent(page: Page): Promise<void> {
 }
 
 /**
+ * Add random human-like delay
+ */
+export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
+  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+/**
  * Priorities for request interception. The higher the number, the higher the priority.
  * We want to let others to have the ability to override our interception logic therefore we hardcode them.
  */

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -6,14 +6,6 @@ export async function maskHeadlessUserAgent(page: Page): Promise<void> {
 }
 
 /**
- * Add random human-like delay
- */
-export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
-}
-
-/**
  * Priorities for request interception. The higher the number, the higher the priority.
  * We want to let others to have the ability to override our interception logic therefore we hardcode them.
  */

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -75,7 +75,7 @@ export async function fetchGetWithinPage<TResult>(
   }, url);
 
   // Check for automation blocking
-  if (status === 429 || (result && (result.includes('Block Automation') || result.includes('bot detection')))) {
+  if (status === 429 || (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))) {
     throw new Error(
       `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
     );

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -73,6 +73,14 @@ export async function fetchGetWithinPage<TResult>(
       );
     }
   }, url);
+
+  // Check for automation blocking
+  if (status === 429 || (result && (result.includes('Block Automation') || result.includes('bot detection')))) {
+    throw new Error(
+      `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
+    );
+  }
+
   if (result !== null) {
     try {
       return JSON.parse(result);
@@ -107,23 +115,35 @@ export async function fetchPostWithinPage<TResult>(
         ),
       });
       if (response.status === 204) {
-        return null;
+        return [null, response.status] as const;
       }
-      return response.text();
+      return [await response.text(), response.status] as const;
     },
     url,
     data,
     extraHeaders,
   );
 
+  const [resultText, status] = result;
+
+  // Check for automation blocking
+  if (
+    status === 429 ||
+    (resultText && (resultText.includes('Block Automation') || resultText.includes('bot detection')))
+  ) {
+    throw new Error(
+      `Automation detected and blocked by server. Status: ${status}, URL: ${url}. Your IP may be temporarily rate-limited from recent scraping attempts. Wait 10-15 minutes before trying again. Consider: 1) Waiting between scraping sessions, 2) Using residential proxies, 3) Running at different times of day`,
+    );
+  }
+
   try {
-    if (result !== null) {
-      return JSON.parse(result);
+    if (resultText !== null) {
+      return JSON.parse(resultText);
     }
   } catch (e) {
     if (!ignoreErrors) {
       throw new Error(
-        `fetchPostWithinPage parse error: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}, url: ${url}, data: ${JSON.stringify(data)}, extraHeaders: ${JSON.stringify(extraHeaders)}, result: ${result}`,
+        `fetchPostWithinPage parse error: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}, url: ${url}, data: ${JSON.stringify(data)}, extraHeaders: ${JSON.stringify(extraHeaders)}, result: ${resultText}`,
       );
     }
   }

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -9,6 +9,14 @@ function getJsonHeaders() {
   };
 }
 
+function assertAutomationNotBlocked(status: number, responseText: string | null, url: string) {
+  if (status === 429 || (responseText && /block automation|bot detection/i.test(responseText))) {
+    throw new Error(
+      `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
+    );
+  }
+}
+
 export async function fetchGet<TResult>(url: string, extraHeaders: Record<string, any>): Promise<TResult> {
   let headers = getJsonHeaders();
   if (extraHeaders) {
@@ -74,14 +82,8 @@ export async function fetchGetWithinPage<TResult>(
     }
   }, url);
 
-  // Check for automation blocking
-  if (
-    status === 429 ||
-    (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))
-  ) {
-    throw new Error(
-      `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
-    );
+  if (!ignoreErrors) {
+    assertAutomationNotBlocked(status, result, url);
   }
 
   if (result !== null) {
@@ -129,14 +131,8 @@ export async function fetchPostWithinPage<TResult>(
 
   const [resultText, status] = result;
 
-  // Check for automation blocking
-  if (
-    status === 429 ||
-    (resultText && (resultText.includes('Block Automation') || resultText.includes('bot detection')))
-  ) {
-    throw new Error(
-      `Automation detected and blocked by server. Status: ${status}, URL: ${url}. Your IP may be temporarily rate-limited from recent scraping attempts. Wait 10-15 minutes before trying again. Consider: 1) Waiting between scraping sessions, 2) Using residential proxies, 3) Running at different times of day`,
-    );
+  if (!ignoreErrors) {
+    assertAutomationNotBlocked(status, resultText, url);
   }
 
   try {

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -75,7 +75,10 @@ export async function fetchGetWithinPage<TResult>(
   }, url);
 
   // Check for automation blocking
-  if (status === 429 || (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))) {
+  if (
+    status === 429 ||
+    (result && (result.toLowerCase().includes('block automation') || result.toLowerCase().includes('bot detection')))
+  ) {
     throw new Error(
       `Automation detected and blocked by server. Status: ${status}, URL: ${url}. The site is actively blocking automated access. Consider: 1) Using showBrowser:true, 2) Adding longer delays, 3) Using residential proxies, 4) Running at different times of day`,
     );

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -107,7 +107,7 @@ export async function fetchPostWithinPage<TResult>(
   extraHeaders: Record<string, any> = {},
   ignoreErrors = false,
 ): Promise<TResult | null> {
-  const result = await page.evaluate(
+  const [resultText, status] = await page.evaluate(
     async (innerUrl: string, innerData: Record<string, any>, innerExtraHeaders: Record<string, any>) => {
       const response = await fetch(innerUrl, {
         method: 'POST',
@@ -128,8 +128,6 @@ export async function fetchPostWithinPage<TResult>(
     data,
     extraHeaders,
   );
-
-  const [resultText, status] = result;
 
   if (!ignoreErrors) {
     assertAutomationNotBlocked(status, resultText, url);

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -63,3 +63,11 @@ export function runSerial<T>(actions: (() => Promise<T>)[]): Promise<T[]> {
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Add random human-like delay
+ */
+export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
+  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
+  return new Promise(resolve => setTimeout(resolve, delay));
+}

--- a/src/helpers/waiting.ts
+++ b/src/helpers/waiting.ts
@@ -64,9 +64,6 @@ export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/**
- * Add random human-like delay
- */
 export function randomDelay(min: number = 500, max: number = 2000): Promise<void> {
   const delay = Math.floor(Math.random() * (max - min + 1)) + min;
   return new Promise(resolve => setTimeout(resolve, delay));

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -2,12 +2,13 @@ import moment, { type Moment } from 'moment';
 import { type Page } from 'puppeteer';
 import { ALT_SHEKEL_CURRENCY, SHEKEL_CURRENCY, SHEKEL_CURRENCY_KEYWORD } from '../constants';
 import { ScraperProgressTypes } from '../definitions';
+import { interceptionPriorities, maskHeadlessUserAgent } from '../helpers/browser';
 import getAllMonthMoments from '../helpers/dates';
 import { getDebug } from '../helpers/debug';
 import { fetchGetWithinPage, fetchPostWithinPage } from '../helpers/fetch';
 import { chunk } from '../helpers/arrays';
 import { filterOldTransactions, fixInstallments, getRawTransaction } from '../helpers/transactions';
-import { runSerial, sleep } from '../helpers/waiting';
+import { randomDelay, runSerial, sleep } from '../helpers/waiting';
 import {
   TransactionStatuses,
   TransactionTypes,
@@ -18,7 +19,6 @@ import {
 import { BaseScraperWithBrowser } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
-import { interceptionPriorities, maskHeadlessUserAgent, randomDelay } from '../helpers/browser';
 
 const RATE_LIMIT = {
   SLEEP_BETWEEN: 2500, // Sweet spot: 2.5s base delay (randomized up to 3s)

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -21,7 +21,7 @@ import { type ScraperOptions, type ScraperScrapingResult } from './interface';
 import { interceptionPriorities, maskHeadlessUserAgent, randomDelay } from '../helpers/browser';
 
 const RATE_LIMIT = {
-  SLEEP_BETWEEN: 2500, // Sweet spot: 2.5-3s delays
+  SLEEP_BETWEEN: 2500, // Sweet spot: 2.5s base delay (randomized up to 3s)
   TRANSACTIONS_BATCH_SIZE: 10,
 } as const;
 
@@ -119,13 +119,13 @@ function getAccountsUrl(servicesUrl: string, monthMoment: Moment) {
 }
 
 async function fetchAccounts(page: Page, servicesUrl: string, monthMoment: Moment): Promise<ScrapedAccount[]> {
-  const startTime = Date.now();
+  const startTime = performance.now();
   const dataUrl = getAccountsUrl(servicesUrl, monthMoment);
 
   debug(`fetching accounts for ${monthMoment.format('YYYY-MM')} from ${dataUrl}`);
   await randomDelay(RATE_LIMIT.SLEEP_BETWEEN, RATE_LIMIT.SLEEP_BETWEEN + 500);
   const dataResult = await fetchGetWithinPage<ScrapedAccountsWithinPageResponse>(page, dataUrl);
-  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${Date.now() - startTime}ms`);
+  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${performance.now() - startTime}ms`);
 
   if (dataResult && dataResult.Header?.Status === '1' && dataResult.DashboardMonthBean) {
     const { cardsCharges } = dataResult.DashboardMonthBean;
@@ -228,14 +228,14 @@ async function fetchTransactions(
   startMoment: Moment,
   monthMoment: Moment,
 ): Promise<ScrapedAccountsWithIndex> {
-  const startTime = Date.now();
+  const startTime = performance.now();
   const accounts = await fetchAccounts(page, companyServiceOptions.servicesUrl, monthMoment);
   const dataUrl = getTransactionsUrl(companyServiceOptions.servicesUrl, monthMoment);
 
   debug(`fetching transactions for ${monthMoment.format('YYYY-MM')} from ${dataUrl}`);
   await randomDelay(RATE_LIMIT.SLEEP_BETWEEN, RATE_LIMIT.SLEEP_BETWEEN + 500);
   const dataResult = await fetchGetWithinPage<ScrapedTransactionData>(page, dataUrl);
-  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${Date.now() - startTime}ms`);
+  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${performance.now() - startTime}ms`);
 
   if (dataResult && dataResult.Header?.Status === '1' && dataResult.CardsTransactionsListBean) {
     const accountTxns: ScrapedAccountsWithIndex = {};
@@ -350,7 +350,7 @@ async function fetchAllTransactions(
   companyServiceOptions: CompanyServiceOptions,
   startMoment: Moment,
 ) {
-  const fetchStartTime = Date.now();
+  const fetchStartTime = performance.now();
   const futureMonthsToScrape = options.futureMonthsToScrape ?? 1;
   const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
   debug(`Fetching transactions for ${allMonths.length} months`);
@@ -389,7 +389,7 @@ async function fetchAllTransactions(
     };
   });
 
-  debug(`fetchAllTransactions completed in ${Date.now() - fetchStartTime}ms`);
+  debug(`fetchAllTransactions completed in ${performance.now() - fetchStartTime}ms`);
 
   return {
     success: true,
@@ -414,7 +414,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
   }
 
   async login(credentials: ScraperSpecificCredentials): Promise<ScraperScrapingResult> {
-    const loginStartTime = Date.now();
+    const loginStartTime = performance.now();
     await this.page.setRequestInterception(true);
     this.page.on('request', request => {
       if (request.url().includes('detector-dom.min.js')) {
@@ -471,7 +471,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
 
       if (loginResult && loginResult.status === '1') {
         this.emitProgress(ScraperProgressTypes.LoginSuccess);
-        debug(`Login completed in ${Date.now() - loginStartTime}ms`);
+        debug(`Login completed in ${performance.now() - loginStartTime}ms`);
         return { success: true };
       }
 

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -18,10 +18,10 @@ import {
 import { BaseScraperWithBrowser } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
-import { interceptionPriorities, maskHeadlessUserAgent } from '../helpers/browser';
+import { interceptionPriorities, maskHeadlessUserAgent, randomDelay } from '../helpers/browser';
 
 const RATE_LIMIT = {
-  SLEEP_BETWEEN: 1000,
+  SLEEP_BETWEEN: 2500, // Sweet spot: 2.5-3s delays
   TRANSACTIONS_BATCH_SIZE: 10,
 } as const;
 
@@ -119,9 +119,14 @@ function getAccountsUrl(servicesUrl: string, monthMoment: Moment) {
 }
 
 async function fetchAccounts(page: Page, servicesUrl: string, monthMoment: Moment): Promise<ScrapedAccount[]> {
+  const startTime = Date.now();
   const dataUrl = getAccountsUrl(servicesUrl, monthMoment);
-  debug(`fetching accounts from ${dataUrl}`);
+
+  debug(`fetching accounts for ${monthMoment.format('YYYY-MM')} from ${dataUrl}`);
+  await randomDelay(RATE_LIMIT.SLEEP_BETWEEN, RATE_LIMIT.SLEEP_BETWEEN + 500);
   const dataResult = await fetchGetWithinPage<ScrapedAccountsWithinPageResponse>(page, dataUrl);
+  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${Date.now() - startTime}ms`);
+
   if (dataResult && dataResult.Header?.Status === '1' && dataResult.DashboardMonthBean) {
     const { cardsCharges } = dataResult.DashboardMonthBean;
     if (cardsCharges) {
@@ -223,11 +228,15 @@ async function fetchTransactions(
   startMoment: Moment,
   monthMoment: Moment,
 ): Promise<ScrapedAccountsWithIndex> {
+  const startTime = Date.now();
   const accounts = await fetchAccounts(page, companyServiceOptions.servicesUrl, monthMoment);
   const dataUrl = getTransactionsUrl(companyServiceOptions.servicesUrl, monthMoment);
-  await sleep(RATE_LIMIT.SLEEP_BETWEEN);
-  debug(`fetching transactions from ${dataUrl} for month ${monthMoment.format('YYYY-MM')}`);
+
+  debug(`fetching transactions for ${monthMoment.format('YYYY-MM')} from ${dataUrl}`);
+  await randomDelay(RATE_LIMIT.SLEEP_BETWEEN, RATE_LIMIT.SLEEP_BETWEEN + 500);
   const dataResult = await fetchGetWithinPage<ScrapedTransactionData>(page, dataUrl);
+  debug(`Fetch for ${monthMoment.format('YYYY-MM')} completed in ${Date.now() - startTime}ms`);
+
   if (dataResult && dataResult.Header?.Status === '1' && dataResult.CardsTransactionsListBean) {
     const accountTxns: ScrapedAccountsWithIndex = {};
     accounts.forEach(account => {
@@ -341,8 +350,11 @@ async function fetchAllTransactions(
   companyServiceOptions: CompanyServiceOptions,
   startMoment: Moment,
 ) {
+  const fetchStartTime = Date.now();
   const futureMonthsToScrape = options.futureMonthsToScrape ?? 1;
   const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
+  debug(`Fetching transactions for ${allMonths.length} months`);
+
   const results: ScrapedAccountsWithIndex[] = await runSerial(
     allMonths.map(monthMoment => () => {
       return fetchTransactions(page, options, companyServiceOptions, startMoment, monthMoment);
@@ -377,6 +389,8 @@ async function fetchAllTransactions(
     };
   });
 
+  debug(`fetchAllTransactions completed in ${Date.now() - fetchStartTime}ms`);
+
   return {
     success: true,
     accounts,
@@ -400,6 +414,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
   }
 
   async login(credentials: ScraperSpecificCredentials): Promise<ScraperScrapingResult> {
+    const loginStartTime = Date.now();
     await this.page.setRequestInterception(true);
     this.page.on('request', request => {
       if (request.url().includes('detector-dom.min.js')) {
@@ -456,6 +471,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
 
       if (loginResult && loginResult.status === '1') {
         this.emitProgress(ScraperProgressTypes.LoginSuccess);
+        debug(`Login completed in ${Date.now() - loginStartTime}ms`);
         return { success: true };
       }
 


### PR DESCRIPTION
- Added more delay during Isracard requests to prevent triggering the bot detection
- Added proper handling for when a request is blocked due to automation detection

Tested locally. Accounts scraped successfully. For example:
```
{
  "success": true,
  "accounts": [
    {
      "accountNumber": "XXXX",
      "txns": [
        {
          "type": "normal",
          "identifier": 754530882,
          "date": "2025-01-22T22:00:00.000Z",
          "processedDate": "2025-02-19T22:00:00.000Z",
          "originalAmount": -7.8,
          "originalCurrency": "ILS",
          "chargedAmount": 0,
          "chargedCurrency": "ILS",
          "description": "פועלים- דמי כרטיס",
          "memo": "הנחה 7.80       ש\"ח מימון כל א",
          "status": "completed"
        }
      ]
    }
  ]
}
```
