### PR TITLE
feat(leumi): add savings accounts

### DIFF
--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -50,4 +50,41 @@ describe('Leumi legacy scraper', () => {
 
     exportTransactions(COMPANY_ID, result.accounts || []);
   });
+
+  maybeTestCompanyAPI(COMPANY_ID)('should include savings accounts', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: COMPANY_ID,
+    };
+
+    const scraper = new LeumiScraper(options);
+    const result = await scraper.scrape(testsConfig.credentials.leumi);
+
+    expect(result).toBeDefined();
+    expect(result.success).toBeTruthy();
+    expect(result.accounts).toBeDefined();
+
+    // Check if any savings accounts are present
+    const savingsAccounts = result.accounts?.filter(account => account.savingsAccount === true);
+
+    console.log('Total accounts:', result.accounts?.length);
+    console.log('Savings accounts found:', savingsAccounts?.length);
+
+    if (savingsAccounts && savingsAccounts.length > 0) {
+      console.log('Savings account details:');
+      savingsAccounts.forEach(account => {
+        console.log(`  - Account: ${account.accountNumber}, Balance: ${account.balance}`);
+      });
+
+      // Verify savings account properties
+      savingsAccounts.forEach(account => {
+        expect(account.savingsAccount).toBe(true);
+        expect(account.accountNumber).toMatch(/ID/);
+        expect(account.balance).toBeDefined();
+        expect(account.txns).toBeDefined();
+      });
+    } else {
+      console.log('No savings accounts found - this may be expected if the test account has no deposits');
+    }
+  });
 });

--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -51,22 +51,9 @@ describe('Leumi legacy scraper', () => {
     expect(result.success).toBeTruthy();
 
     exportTransactions(COMPANY_ID, result.accounts || []);
-  });
 
-  maybeTestCompanyAPI(COMPANY_ID)('should include savings accounts', async () => {
-    const options = {
-      ...testsConfig.options,
-      companyId: COMPANY_ID,
-    };
-
-    const scraper = new LeumiScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.leumi);
-
-    expect(result).toBeDefined();
-    expect(result.success).toBeTruthy();
+    // Validate savings accounts if they exist
     expect(result.accounts).toBeDefined();
-
-    // Check if any savings accounts are present
     const savingsAccounts = result.accounts?.filter(account => account.savingsAccount === true);
 
     debug('Total accounts:', result.accounts?.length);

--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -1,10 +1,12 @@
-import LeumiScraper from './leumi';
-import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
 import { LoginResults } from './base-scraper-with-browser';
+import LeumiScraper from './leumi';
+import { SCRAPERS } from '../definitions';
+import { getDebug } from '../helpers/debug';
+import { exportTransactions, extendAsyncTimeout, getTestsConfig, maybeTestCompanyAPI } from '../tests/tests-utils';
 
 const COMPANY_ID = 'leumi'; // TODO this property should be hard-coded in the provider
 const testsConfig = getTestsConfig();
+const debug = getDebug('leumi-test');
 
 describe('Leumi legacy scraper', () => {
   beforeAll(() => {
@@ -67,13 +69,13 @@ describe('Leumi legacy scraper', () => {
     // Check if any savings accounts are present
     const savingsAccounts = result.accounts?.filter(account => account.savingsAccount === true);
 
-    console.log('Total accounts:', result.accounts?.length);
-    console.log('Savings accounts found:', savingsAccounts?.length);
+    debug('Total accounts:', result.accounts?.length);
+    debug('Savings accounts found:', savingsAccounts?.length);
 
     if (savingsAccounts && savingsAccounts.length > 0) {
-      console.log('Savings account details:');
+      debug('Savings account details:');
       savingsAccounts.forEach(account => {
-        console.log(`  - Account: ${account.accountNumber}, Balance: ${account.balance}`);
+        debug(`  - Account: ${account.accountNumber}, Balance: ${account.balance}`);
       });
 
       // Verify savings account properties
@@ -84,7 +86,7 @@ describe('Leumi legacy scraper', () => {
         expect(account.txns).toBeDefined();
       });
     } else {
-      console.log('No savings accounts found - this may be expected if the test account has no deposits');
+      debug('No savings accounts found - this may be expected if the test account has no deposits');
     }
   });
 });

--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -2,7 +2,7 @@ import moment, { type Moment } from 'moment';
 import { type Page } from 'puppeteer';
 import { SHEKEL_CURRENCY } from '../constants';
 import { getDebug } from '../helpers/debug';
-import { clickButton, fillInput, pageEval, pageEvalAll, waitUntilElementFound } from '../helpers/elements-interactions';
+import { clickButton, fillInput, pageEvalAll, waitUntilElementFound } from '../helpers/elements-interactions';
 import { fetchGetWithinPage } from '../helpers/fetch';
 import { getRawTransaction } from '../helpers/transactions';
 import { waitForNavigation } from '../helpers/navigation';
@@ -283,15 +283,8 @@ async function fetchTransactions(
 }
 
 async function navigateToLogin(page: Page): Promise<void> {
-  const loginButtonSelector = '.enter_account';
-  debug('wait for homepage to click on login button');
-  await waitUntilElementFound(page, loginButtonSelector);
-  debug('navigate to login page');
-  const loginUrl = await pageEval(page, loginButtonSelector, null, element => {
-    return (element as any).href;
-  });
-  debug(`navigating to page (${loginUrl})`);
-  await page.goto(loginUrl);
+  debug('navigating directly to login page');
+  await page.goto('https://hb2.bankleumi.co.il/authenticate/logon');
   debug('waiting for page to be loaded (networkidle2)');
   await waitForNavigation(page, { waitUntil: 'networkidle2' });
   debug('waiting for components of login to enter credentials');

--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -15,6 +15,7 @@ const BASE_URL = 'https://hb2.bankleumi.co.il';
 const LOGIN_URL = 'https://www.leumi.co.il/he';
 const TRANSACTIONS_URL = `${BASE_URL}/eBanking/SO/SPA.aspx#/ts/BusinessAccountTrx?WidgetPar=1`;
 const FILTERED_TRANSACTIONS_URL = `${BASE_URL}/ChannelWCF/Broker.svc/ProcessRequest?moduleName=UC_SO_27_GetBusinessAccountTrx`;
+const SAVINGS_URL = `${BASE_URL}/uiapiproxy/v1/digital-retails/mobile/accounts/1/Deposits?operationList=true`;
 
 const DATE_FORMAT = 'DD.MM.YY';
 const ACCOUNT_BLOCKED_MSG = 'המנוי חסום';
@@ -204,6 +205,16 @@ async function fetchTransactionsForAccount(
   };
 }
 
+async function fetchRegularAccounts(
+  scraper: LeumiScraper,
+  page: Page,
+  startDate: Moment,
+  options: ScraperOptions,
+): Promise<TransactionsAccount[]> {
+  await scraper.navigateTo(TRANSACTIONS_URL);
+  return fetchTransactions(page, startDate, options);
+}
+
 async function getSavingsAccounts(page: Page, accountId: string): Promise<TransactionsAccount[]> {
   debug('========== FETCHING SAVINGS ACCOUNTS ==========');
   debug('Account: %s', accountId);
@@ -211,10 +222,9 @@ async function getSavingsAccounts(page: Page, accountId: string): Promise<Transa
   const accounts: TransactionsAccount[] = [];
 
   try {
-    const savingsUrl = `${BASE_URL}/uiapiproxy/v1/digital-retails/mobile/accounts/1/Deposits?operationList=true`;
-    debug('Trying savings URL: %s', savingsUrl);
+    debug('Trying savings URL: %s', SAVINGS_URL);
 
-    const savingsData = await fetchGetWithinPage<SavingsAccountData>(page, savingsUrl);
+    const savingsData = await fetchGetWithinPage<SavingsAccountData>(page, SAVINGS_URL);
     if (!savingsData || !savingsData.depositsAndSavingsItems || savingsData.depositsAndSavingsItems.length === 0) {
       debug('No savings accounts found for account %s', accountId);
       return [];
@@ -282,6 +292,26 @@ async function fetchTransactions(
   return accounts;
 }
 
+async function fetchSavingsAccounts(
+  page: Page,
+  regularAccounts: TransactionsAccount[],
+): Promise<TransactionsAccount[]> {
+  const allSavingsAccounts: TransactionsAccount[] = [];
+  const regularAccountCount = regularAccounts.length;
+
+  for (let i = 0; i < regularAccountCount; i++) {
+    try {
+      const savingsAccounts = await getSavingsAccounts(page, regularAccounts[i].accountNumber);
+      allSavingsAccounts.push(...savingsAccounts);
+      debug('Added %d savings accounts to results', savingsAccounts.length);
+    } catch (error) {
+      debug('Error fetching savings accounts for %s: %s', regularAccounts[i].accountNumber, error);
+    }
+  }
+
+  return allSavingsAccounts;
+}
+
 async function navigateToLogin(page: Page): Promise<void> {
   debug('navigating directly to login page');
   await page.goto('https://hb2.bankleumi.co.il/authenticate/logon');
@@ -324,22 +354,9 @@ class LeumiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
     const startDate = this.options.startDate || defaultStartMoment.toDate();
     const startMoment = moment.max(minimumStartMoment, moment(startDate));
 
-    await this.navigateTo(TRANSACTIONS_URL);
-
-    // Fetch regular accounts
-    const accounts = await fetchTransactions(this.page, startMoment, this.options);
-
-    // Fetch savings accounts for each regular account
-    const regularAccountCount = accounts.length;
-    for (let i = 0; i < regularAccountCount; i++) {
-      try {
-        const savingsAccounts = await getSavingsAccounts(this.page, accounts[i].accountNumber);
-        accounts.push(...savingsAccounts);
-        debug('Added %d savings accounts to results', savingsAccounts.length);
-      } catch (error) {
-        debug('Error fetching savings accounts for %s: %s', accounts[i].accountNumber, error);
-      }
-    }
+    const accounts = await fetchRegularAccounts(this, this.page, startMoment, this.options);
+    const savingsAccounts = await fetchSavingsAccounts(this.page, accounts);
+    accounts.push(...savingsAccounts);
 
     return {
       success: true,

--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -3,6 +3,7 @@ import { type Page } from 'puppeteer';
 import { SHEKEL_CURRENCY } from '../constants';
 import { getDebug } from '../helpers/debug';
 import { clickButton, fillInput, pageEval, pageEvalAll, waitUntilElementFound } from '../helpers/elements-interactions';
+import { fetchGetWithinPage } from '../helpers/fetch';
 import { getRawTransaction } from '../helpers/transactions';
 import { waitForNavigation } from '../helpers/navigation';
 import { TransactionStatuses, TransactionTypes, type Transaction, type TransactionsAccount } from '../transactions';
@@ -19,6 +20,42 @@ const DATE_FORMAT = 'DD.MM.YY';
 const ACCOUNT_BLOCKED_MSG = 'המנוי חסום';
 const INVALID_PASSWORD_MSG = 'אחד או יותר מפרטי ההזדהות שמסרת שגויים. ניתן לנסות שוב';
 const CHANGE_PASSWORD_MODAL_SELECTOR = 'form input[name="newPwd"]';
+
+interface SavingsDepositItem {
+  index: string;
+  depositId: string;
+  depositIndex: number;
+  depositSourceId: string;
+  type: number;
+  displayName: string;
+  productName: string;
+  friendlyAccountName: string;
+  deepLink: string;
+  isForeclosed: boolean;
+  asOfDate: string;
+  createDate: string;
+  exitPointDate: string;
+  currentBalance: number;
+  initialAmount: number | null;
+  installmentsSavingFlag: boolean;
+  marginRate: string;
+  productInterestType: string | null;
+  productLinkageType: string | null;
+  sourceSystem: string;
+  depositNumber: string;
+  relatedAccountNumber: string;
+  withdrawalRequestText: string | null;
+  WithdrawalAvailableFrequency: string | null;
+  depositOperationsItems: any[];
+}
+
+interface SavingsAccountData {
+  totalDepositsAndSavingsBalance: number;
+  previousBusinessDayDate: string;
+  depositsAndSavingsItems: SavingsDepositItem[];
+  operationsItemsTotal: string;
+  operationsListItems: any[];
+}
 
 function getPossibleLoginResults() {
   const urls: LoginOptions['possibleResults'] = {
@@ -167,6 +204,50 @@ async function fetchTransactionsForAccount(
   };
 }
 
+async function getSavingsAccounts(page: Page, accountId: string): Promise<TransactionsAccount[]> {
+  debug('========== FETCHING SAVINGS ACCOUNTS ==========');
+  debug('Account: %s', accountId);
+
+  const accounts: TransactionsAccount[] = [];
+
+  try {
+    const savingsUrl = `${BASE_URL}/uiapiproxy/v1/digital-retails/mobile/accounts/1/Deposits?operationList=true`;
+    debug('Trying savings URL: %s', savingsUrl);
+
+    const savingsData = await fetchGetWithinPage<SavingsAccountData>(page, savingsUrl);
+    if (!savingsData || !savingsData.depositsAndSavingsItems || savingsData.depositsAndSavingsItems.length === 0) {
+      debug('No savings accounts found for account %s', accountId);
+      return [];
+    }
+    debug('✓ Found %d savings deposits', savingsData.depositsAndSavingsItems.length);
+
+    // Create a separate account for each individual deposit
+    for (const deposit of savingsData.depositsAndSavingsItems) {
+      const balance = deposit.currentBalance;
+      const savingsAccountNumber = `${accountId}-${deposit.depositId}`;
+
+      accounts.push({
+        accountNumber: savingsAccountNumber,
+        savingsAccount: true,
+        balance,
+        txns: [],
+      });
+
+      debug(
+        'Added savings account %s with balance %s (product: %s)',
+        savingsAccountNumber,
+        balance,
+        deposit.productName,
+      );
+    }
+  } catch (error) {
+    debug('  - Error fetching savings accounts: %s', error);
+  }
+
+  debug('Returning %d savings accounts', accounts.length);
+  return accounts;
+}
+
 async function fetchTransactions(
   page: Page,
   startDate: Moment,
@@ -252,7 +333,20 @@ class LeumiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
 
     await this.navigateTo(TRANSACTIONS_URL);
 
+    // Fetch regular accounts
     const accounts = await fetchTransactions(this.page, startMoment, this.options);
+
+    // Fetch savings accounts for each regular account
+    const regularAccountCount = accounts.length;
+    for (let i = 0; i < regularAccountCount; i++) {
+      try {
+        const savingsAccounts = await getSavingsAccounts(this.page, accounts[i].accountNumber);
+        accounts.push(...savingsAccounts);
+        debug('Added %d savings accounts to results', savingsAccounts.length);
+      } catch (error) {
+        debug('Error fetching savings accounts for %s: %s', accounts[i].accountNumber, error);
+      }
+    }
 
     return {
       success: true,

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,6 +4,8 @@ export interface TransactionsAccount {
   balanceDate?: string;
   cardFrame?: number;
   cardType?: CardType;
+  currency?: string;
+  savingsAccount?: boolean;
   txns: Transaction[];
 }
 


### PR DESCRIPTION
- Adds support for scraping Bank Leumi savings account balances
- Fixed scraping failing due to the change in the login button element

Tested locally. New accounts in output look like:
```json
{
  "accountNumber": "XXX-XXXX_XX",
  "balance": 1000,
  "txns": [
    {
      "status": "completed",
      "type": "normal",
      "date": "2025-12-21T22:00:00.000Z",
      "processedDate": "2025-12-21T22:00:00.000Z",
      "description": "פקדון אינטרנט",
      "identifier": 134900,
      "memo": "",
      "originalCurrency": "ILS",
      "chargedAmount": -10000,
      "originalAmount": -10000
    }
  ]
},
{
  "accountNumber": "XXX-XXXX_XX-ID_1",
  "savingsAccount": true,
  "balance": 10000,
  "txns": []
}
```