### PR TITLE
fix(max): scrape fails on login page

### DIFF
--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -366,7 +366,13 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
         if (await elementPresentOnPage(this.page, '.login-link#private')) {
           await clickButton(this.page, '.login-link#private');
         }
-        await waitUntilElementFound(this.page, '#login-password-link', true);
+        // Try twice in case it can't find it the first time
+        try {
+          await waitUntilElementFound(this.page, '#login-password-link', true, 10000);
+        } catch {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          await waitUntilElementFound(this.page, '#login-password-link', true, 10000);
+        }
         await clickButton(this.page, '#login-password-link');
         await waitUntilElementFound(this.page, '#login-password.tab-pane.active app-user-login-form', true);
       },

--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -12,6 +12,7 @@ import {
   sortTransactionsByDate,
   getRawTransaction,
 } from '../helpers/transactions';
+import { sleep } from '../helpers/waiting';
 import { TransactionStatuses, TransactionTypes, type Transaction } from '../transactions';
 import {
   BaseScraperWithBrowser,
@@ -370,7 +371,7 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
         try {
           await waitUntilElementFound(this.page, '#login-password-link', true, 10000);
         } catch {
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await sleep(1000);
           await waitUntilElementFound(this.page, '#login-password-link', true, 10000);
         }
         await clickButton(this.page, '#login-password-link');


### PR DESCRIPTION
Sometimes, Max scraping will fail on the login page with the error `GENERIC - Waiting for selector '#login-password-link; failed`, despite the `#login-password-link` being present. This attempts to rectify that by checking for the element two seperate times.