### PR TITLE
feat(visa-cal): complete unfinished frame implementation

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -492,6 +492,118 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     };
   }
 
+  private async fetchCardData(
+    card: { cardUniqueId: string; last4Digits: string },
+    startMoment: moment.Moment,
+    startDate: Date,
+    futureMonthsToScrape: number,
+    Authorization: string,
+    xSiteId: string,
+  ): Promise<TransactionsAccount> {
+    debug('fetch frames (misgarot) for card %s', card.cardUniqueId);
+    const frames = await fetchPost<FramesResponse>(
+      FRAMES_REQUEST_ENDPOINT,
+      { cardsForFrameData: [{ cardUniqueId: card.cardUniqueId }] },
+      {
+        Authorization,
+        'X-Site-Id': xSiteId,
+        'Content-Type': 'application/json',
+        ...apiHeaders,
+      },
+    );
+
+    debug('frames response for card %s: %O', card.cardUniqueId, frames);
+
+    // Look for card-level frame in both calIssuedCards and bankIssuedCards
+    let frame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
+      (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
+    );
+
+    if (!frame) {
+      frame = frames.result?.calIssuedCards?.cardLevelFrames?.find(
+        (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
+      );
+    }
+
+    debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
+
+    // Determine which group this card belongs to for account-level balance fallback
+    const accountGroup = frames.result?.bankIssuedCards || frames.result?.calIssuedCards;
+    const balanceDate: string | null | undefined = accountGroup?.nextTotalDebitDateForAccount;
+
+    const finalMonthToFetchMoment = moment().add(futureMonthsToScrape, 'month');
+    const months = finalMonthToFetchMoment.diff(startMoment, 'months');
+    const allMonthsData: CardTransactionDetails[] = [];
+
+    debug(`fetch pending transactions for card ${card.cardUniqueId}`);
+    let pendingData = await fetchPost(
+      PENDING_TRANSACTIONS_REQUEST_ENDPOINT,
+      { cardUniqueIDArray: [card.cardUniqueId] },
+      {
+        Authorization,
+        'X-Site-Id': xSiteId,
+        'Content-Type': 'application/json',
+        ...apiHeaders,
+      },
+    );
+
+    debug(`fetch completed transactions for card ${card.cardUniqueId}`);
+    for (let i = 0; i <= months; i++) {
+      const month = finalMonthToFetchMoment.clone().subtract(i, 'months');
+      const monthData = await fetchPost(
+        TRANSACTIONS_REQUEST_ENDPOINT,
+        { cardUniqueId: card.cardUniqueId, month: month.format('M'), year: month.format('YYYY') },
+        {
+          Authorization,
+          'X-Site-Id': xSiteId,
+          'Content-Type': 'application/json',
+          ...apiHeaders,
+        },
+      );
+
+      if (monthData?.statusCode !== 1)
+        throw new Error(
+          `failed to fetch transactions for card ${card.last4Digits}. Message: ${monthData?.title || ''}`,
+        );
+
+      if (!isCardTransactionDetails(monthData)) {
+        throw new Error('monthData is not of type CardTransactionDetails');
+      }
+
+      allMonthsData.push(monthData);
+    }
+
+    if (pendingData?.statusCode !== 1 && pendingData?.statusCode !== 96) {
+      debug(
+        `failed to fetch pending transactions for card ${card.last4Digits}. Message: ${pendingData?.title || ''}`,
+      );
+      pendingData = null;
+    } else if (!isCardPendingTransactionDetails(pendingData)) {
+      debug('pendingData is not of type CardTransactionDetails');
+      pendingData = null;
+    }
+
+    const transactions = convertParsedDataToTransactions(allMonthsData, pendingData, this.options);
+
+    debug('filter out old transactions');
+    const txns =
+      (this.options.outputData?.enableTransactionsFilterByDate ?? true)
+        ? filterOldTransactions(transactions, moment(startDate), this.options.combineInstallments || false)
+        : transactions;
+
+    // Use card-level balance if available, otherwise fall back to account-level balance
+    const balanceAmount = frame?.nextTotalDebit ?? accountGroup?.nextTotalDebitForAccount;
+    const result: TransactionsAccount = {
+      txns,
+      balance: balanceAmount != null ? -balanceAmount : undefined,
+      balanceDate: balanceDate != null ? balanceDate : undefined,
+      accountNumber: card.last4Digits,
+      cardFrame: accountGroup?.frameLimitForCardAmount,
+    };
+
+    return result;
+  }
+
   async fetchData(): Promise<ScraperScrapingResult> {
     const defaultStartMoment = moment().subtract(1, 'years').subtract(6, 'months').add(1, 'day');
     const startDate = this.options.startDate || defaultStartMoment.toDate();
@@ -507,110 +619,9 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     const futureMonthsToScrape = this.options.futureMonthsToScrape ?? 1;
 
     const accounts = await Promise.all(
-      cards.map(async card => {
-        debug('fetch frames (misgarot) for card %s', card.cardUniqueId);
-        const frames = await fetchPost<FramesResponse>(
-          FRAMES_REQUEST_ENDPOINT,
-          { cardsForFrameData: [{ cardUniqueId: card.cardUniqueId }] },
-          {
-            Authorization,
-            'X-Site-Id': xSiteId,
-            'Content-Type': 'application/json',
-            ...apiHeaders,
-          },
-        );
-
-        debug('frames response for card %s: %O', card.cardUniqueId, frames);
-
-        // Look for card-level frame in both calIssuedCards and bankIssuedCards
-        let frame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
-          (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
-        );
-
-        if (!frame) {
-          frame = frames.result?.calIssuedCards?.cardLevelFrames?.find(
-            (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
-          );
-        }
-
-        debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
-
-        // Determine which group this card belongs to for account-level balance fallback
-        const accountGroup = frames.result?.bankIssuedCards || frames.result?.calIssuedCards;
-        const balanceDate: string | null | undefined = accountGroup?.nextTotalDebitDateForAccount;
-
-        const finalMonthToFetchMoment = moment().add(futureMonthsToScrape, 'month');
-        const months = finalMonthToFetchMoment.diff(startMoment, 'months');
-        const allMonthsData: CardTransactionDetails[] = [];
-
-        debug(`fetch pending transactions for card ${card.cardUniqueId}`);
-        let pendingData = await fetchPost(
-          PENDING_TRANSACTIONS_REQUEST_ENDPOINT,
-          { cardUniqueIDArray: [card.cardUniqueId] },
-          {
-            Authorization,
-            'X-Site-Id': xSiteId,
-            'Content-Type': 'application/json',
-            ...apiHeaders,
-          },
-        );
-
-        debug(`fetch completed transactions for card ${card.cardUniqueId}`);
-        for (let i = 0; i <= months; i++) {
-          const month = finalMonthToFetchMoment.clone().subtract(i, 'months');
-          const monthData = await fetchPost(
-            TRANSACTIONS_REQUEST_ENDPOINT,
-            { cardUniqueId: card.cardUniqueId, month: month.format('M'), year: month.format('YYYY') },
-            {
-              Authorization,
-              'X-Site-Id': xSiteId,
-              'Content-Type': 'application/json',
-              ...apiHeaders,
-            },
-          );
-
-          if (monthData?.statusCode !== 1)
-            throw new Error(
-              `failed to fetch transactions for card ${card.last4Digits}. Message: ${monthData?.title || ''}`,
-            );
-
-          if (!isCardTransactionDetails(monthData)) {
-            throw new Error('monthData is not of type CardTransactionDetails');
-          }
-
-          allMonthsData.push(monthData);
-        }
-
-        if (pendingData?.statusCode !== 1 && pendingData?.statusCode !== 96) {
-          debug(
-            `failed to fetch pending transactions for card ${card.last4Digits}. Message: ${pendingData?.title || ''}`,
-          );
-          pendingData = null;
-        } else if (!isCardPendingTransactionDetails(pendingData)) {
-          debug('pendingData is not of type CardTransactionDetails');
-          pendingData = null;
-        }
-
-        const transactions = convertParsedDataToTransactions(allMonthsData, pendingData, this.options);
-
-        debug('filter out old transactions');
-        const txns =
-          (this.options.outputData?.enableTransactionsFilterByDate ?? true)
-            ? filterOldTransactions(transactions, moment(startDate), this.options.combineInstallments || false)
-            : transactions;
-
-        // Use card-level balance if available, otherwise fall back to account-level balance
-        const balanceAmount = frame?.nextTotalDebit ?? accountGroup?.nextTotalDebitForAccount;
-        const result: TransactionsAccount = {
-          txns,
-          balance: balanceAmount != null ? -balanceAmount : undefined,
-          balanceDate: balanceDate != null ? balanceDate : undefined,
-          accountNumber: card.last4Digits,
-          cardFrame: accountGroup?.frameLimitForCardAmount,
-        };
-
-        return result;
-      }),
+      cards.map(card =>
+        this.fetchCardData(card, startMoment, startDate, futureMonthsToScrape, Authorization, xSiteId),
+      ),
     );
 
     debug('return the scraped accounts');

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -7,7 +7,13 @@ import { getCurrentUrl, waitForNavigation } from '../helpers/navigation';
 import { getFromSessionStorage } from '../helpers/storage';
 import { filterOldTransactions, getRawTransaction } from '../helpers/transactions';
 import { waitUntil } from '../helpers/waiting';
-import { TransactionStatuses, TransactionTypes, type Transaction, type TransactionsAccount } from '../transactions';
+import {
+  CardType,
+  TransactionStatuses,
+  TransactionTypes,
+  type Transaction,
+  type TransactionsAccount,
+} from '../transactions';
 import { BaseScraperWithBrowser, LoginResults, type LoginOptions } from './base-scraper-with-browser';
 import { type ScraperScrapingResult, type ScraperOptions } from './interface';
 
@@ -515,20 +521,31 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     debug('frames response for card %s: %O', card.cardUniqueId, frames);
 
     // Look for card-level frame in both calIssuedCards and bankIssuedCards
-    let frame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
+    const bankIssuedFrame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
       (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
     );
 
-    if (!frame) {
-      frame = frames.result?.calIssuedCards?.cardLevelFrames?.find(
-        (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
-      );
+    const calIssuedFrame = frames.result?.calIssuedCards?.cardLevelFrames?.find(
+      (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
+    );
+
+    let frame: CardLevelFrame | undefined;
+    let cardType: CardType;
+    let accountGroup: IssuedCardsGroup | undefined;
+
+    if (bankIssuedFrame) {
+      frame = bankIssuedFrame;
+      cardType = CardType.BankIssued;
+      accountGroup = frames.result?.bankIssuedCards;
+    } else {
+      frame = calIssuedFrame;
+      cardType = CardType.CompanyIssued;
+      accountGroup = frames.result?.calIssuedCards;
     }
 
     debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
+    debug('card type for card %s: %s', card.cardUniqueId, cardType);
 
-    // Determine which group this card belongs to for account-level balance fallback
-    const accountGroup = frames.result?.bankIssuedCards || frames.result?.calIssuedCards;
     const balanceDate: string | null | undefined = accountGroup?.nextTotalDebitDateForAccount;
 
     const finalMonthToFetchMoment = moment().add(futureMonthsToScrape, 'month');
@@ -574,9 +591,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     }
 
     if (pendingData?.statusCode !== 1 && pendingData?.statusCode !== 96) {
-      debug(
-        `failed to fetch pending transactions for card ${card.last4Digits}. Message: ${pendingData?.title || ''}`,
-      );
+      debug(`failed to fetch pending transactions for card ${card.last4Digits}. Message: ${pendingData?.title || ''}`);
       pendingData = null;
     } else if (!isCardPendingTransactionDetails(pendingData)) {
       debug('pendingData is not of type CardTransactionDetails');
@@ -598,6 +613,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       balance: balanceAmount != null ? -balanceAmount : undefined,
       balanceDate: balanceDate != null ? balanceDate : undefined,
       accountNumber: card.last4Digits,
+      cardType,
       cardFrame: accountGroup?.frameLimitForCardAmount,
     };
 
@@ -619,9 +635,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     const futureMonthsToScrape = this.options.futureMonthsToScrape ?? 1;
 
     const accounts = await Promise.all(
-      cards.map(card =>
-        this.fetchCardData(card, startMoment, startDate, futureMonthsToScrape, Authorization, xSiteId),
-      ),
+      cards.map(card => this.fetchCardData(card, startMoment, startDate, futureMonthsToScrape, Authorization, xSiteId)),
     );
 
     debug('return the scraped accounts');

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -167,11 +167,17 @@ interface CardLevelFrame {
   nextTotalDebit?: number;
 }
 
+interface IssuedCardsGroup {
+  nextTotalDebitForAccount?: number;
+  nextTotalDebitDateForAccount?: string | null;
+  frameLimitForCardAmount?: number;
+  cardLevelFrames?: CardLevelFrame[];
+}
+
 interface FramesResponse {
   result?: {
-    bankIssuedCards?: {
-      cardLevelFrames?: CardLevelFrame[];
-    };
+    calIssuedCards?: IssuedCardsGroup;
+    bankIssuedCards?: IssuedCardsGroup;
   };
 }
 
@@ -500,26 +506,42 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
 
     const futureMonthsToScrape = this.options.futureMonthsToScrape ?? 1;
 
-    debug('fetch frames (misgarot) of cards');
-    const frames = await fetchPost<FramesResponse>(
-      FRAMES_REQUEST_ENDPOINT,
-      { cardsForFrameData: cards.map(({ cardUniqueId }) => ({ cardUniqueId })) },
-      {
-        Authorization,
-        'X-Site-Id': xSiteId,
-        'Content-Type': 'application/json',
-        ...apiHeaders,
-      },
-    );
-
     const accounts = await Promise.all(
       cards.map(async card => {
+        debug('fetch frames (misgarot) for card %s', card.cardUniqueId);
+        const frames = await fetchPost<FramesResponse>(
+          FRAMES_REQUEST_ENDPOINT,
+          { cardsForFrameData: [{ cardUniqueId: card.cardUniqueId }] },
+          {
+            Authorization,
+            'X-Site-Id': xSiteId,
+            'Content-Type': 'application/json',
+            ...apiHeaders,
+          },
+        );
+
+        debug('frames response for card %s: %O', card.cardUniqueId, frames);
+
+        // Look for card-level frame in both calIssuedCards and bankIssuedCards
+        let frame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
+          (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
+        );
+
+        if (!frame) {
+          frame = frames.result?.calIssuedCards?.cardLevelFrames?.find(
+            (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
+          );
+        }
+
+        debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
+
+        // Determine which group this card belongs to for account-level balance fallback
+        const accountGroup = frames.result?.bankIssuedCards || frames.result?.calIssuedCards;
+        const balanceDate: string | null | undefined = accountGroup?.nextTotalDebitDateForAccount;
+
         const finalMonthToFetchMoment = moment().add(futureMonthsToScrape, 'month');
         const months = finalMonthToFetchMoment.diff(startMoment, 'months');
         const allMonthsData: CardTransactionDetails[] = [];
-        const frame = frames.result?.bankIssuedCards?.cardLevelFrames?.find(
-          (f: CardLevelFrame) => f.cardUniqueId === card.cardUniqueId,
-        );
 
         debug(`fetch pending transactions for card ${card.cardUniqueId}`);
         let pendingData = await fetchPost(
@@ -577,11 +599,17 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
             ? filterOldTransactions(transactions, moment(startDate), this.options.combineInstallments || false)
             : transactions;
 
-        return {
+        // Use card-level balance if available, otherwise fall back to account-level balance
+        const balanceAmount = frame?.nextTotalDebit ?? accountGroup?.nextTotalDebitForAccount;
+        const result: TransactionsAccount = {
           txns,
-          balance: frame?.nextTotalDebit != null ? -frame.nextTotalDebit : undefined,
+          balance: balanceAmount != null ? -balanceAmount : undefined,
+          balanceDate: balanceDate != null ? balanceDate : undefined,
           accountNumber: card.last4Digits,
-        } as TransactionsAccount;
+          cardFrame: accountGroup?.frameLimitForCardAmount,
+        };
+
+        return result;
       }),
     );
 

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -171,6 +171,7 @@ interface CardPendingTransactionDetails extends CardTransactionDetailsError {
 interface CardLevelFrame {
   cardUniqueId: string;
   nextTotalDebit?: number;
+  nextDebitDate?: string;
 }
 
 interface IssuedCardsGroup {
@@ -546,7 +547,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
     debug('card type for card %s: %s', card.cardUniqueId, cardType);
 
-    const balanceDate: string | null | undefined = accountGroup?.nextTotalDebitDateForAccount;
+    const balanceDate: string | null | undefined = frame?.nextDebitDate ?? accountGroup?.nextTotalDebitDateForAccount;
 
     const finalMonthToFetchMoment = moment().add(futureMonthsToScrape, 'month');
     const months = finalMonthToFetchMoment.diff(startMoment, 'months');

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -3,7 +3,13 @@ export interface TransactionsAccount {
   balance?: number;
   balanceDate?: string;
   cardFrame?: number;
+  cardType?: CardType;
   txns: Transaction[];
+}
+
+export enum CardType {
+  BankIssued = 'bankIssued',
+  CompanyIssued = 'companyIssued',
 }
 
 export enum TransactionTypes {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,6 +1,8 @@
 export interface TransactionsAccount {
   accountNumber: string;
   balance?: number;
+  balanceDate?: string;
+  cardFrame?: number;
   txns: Transaction[];
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/eshaham/israeli-bank-scrapers/pull/1020

This PR fixes the incomplete implementation for Cal-issued cards and adds the new fields `balanceDate`, `cardFrame`, and `cardType`, representing the next billing date, the total frame for the card type, and the card issuer (the bank or the credit card company), respectively.

Test results when testing locally:
```
{
  "success": true,
  "accounts": [
    {
      "txns": [],
      "balance": 0,
      "accountNumber": "XXXX",
      "cardFrame": 10000,
      "cardType": "bankIssued"
    },
    {
      "txns": [],
      "balance": 70,
      "accountNumber": "YYYY",
      "cardType": "companyIssued"
    },
    {
      "txns": [],
      "balance": -50,
      "balanceDate": "2026-08-02T00:00:00",
      "accountNumber": "ZZZZ",
      "cardType": "companyIssued"
    }
  ]
}
```