### PR TITLE
feat(max): add credit card balances

### DIFF
--- a/src/scrapers/max.ts
+++ b/src/scrapers/max.ts
@@ -13,7 +13,7 @@ import {
   getRawTransaction,
 } from '../helpers/transactions';
 import { sleep } from '../helpers/waiting';
-import { TransactionStatuses, TransactionTypes, type Transaction } from '../transactions';
+import { TransactionStatuses, TransactionTypes, type Transaction, type TransactionsAccount } from '../transactions';
 import {
   BaseScraperWithBrowser,
   LoginResults,
@@ -46,6 +46,7 @@ export interface ScrapedTransaction {
 
 const BASE_API_ACTIONS_URL = 'https://onlinelcapi.max.co.il';
 const BASE_WELCOME_URL = 'https://www.max.co.il';
+const HOME_PAGE_DATA_URL = `${BASE_WELCOME_URL}/api/registered/getHomePageData`;
 
 const LOGIN_URL = `${BASE_WELCOME_URL}/login`;
 const PASSWORD_EXPIRED_URL = `${BASE_WELCOME_URL}/renew-password`;
@@ -79,6 +80,24 @@ enum MaxPlanName {
 
 const INVALID_DETAILS_SELECTOR = '#popupWrongDetails';
 const LOGIN_ERROR_SELECTOR = '#popupCardHoldersLoginError';
+
+interface HomePageCard {
+  Last4Digits: string;
+  CreditLimit: number | null;
+  OpenToBuy: number | null;
+  CycleSummary: Array<{
+    Date: string;
+    CurrencySymbol: string;
+  }>;
+}
+
+interface HomePageDataResult {
+  Result?: {
+    UserCards?: {
+      Cards?: HomePageCard[];
+    };
+  };
+}
 
 const categories = new Map<number, string>();
 
@@ -115,6 +134,29 @@ interface FetchCategoryResult {
     id: number;
     name: string;
   }>;
+}
+
+async function loadHomePageData(page: Page): Promise<Map<string, HomePageCard>> {
+  debug('Loading home page data for card balances');
+  const res = await fetchGetWithinPage<HomePageDataResult>(page, HOME_PAGE_DATA_URL);
+  const cardMap = new Map<string, HomePageCard>();
+  if (res?.Result?.UserCards?.Cards) {
+    for (const card of res.Result.UserCards.Cards) {
+      cardMap.set(card.Last4Digits, card);
+    }
+  }
+  return cardMap;
+}
+
+function getCardBalance(card: HomePageCard): number | undefined {
+  if (card.CreditLimit == null || card.OpenToBuy == null) return undefined;
+  const balance = -(card.CreditLimit - card.OpenToBuy);
+  return Math.round(balance * 100) / 100;
+}
+
+function getCardBalanceDate(card: HomePageCard): string | undefined {
+  const shekelEntry = card.CycleSummary?.find(entry => entry.CurrencySymbol.includes('₪'));
+  return shekelEntry ? shekelEntry.Date : undefined;
 }
 
 async function loadCategories(page: Page) {
@@ -306,6 +348,7 @@ async function fetchTransactions(page: Page, options: ScraperOptions) {
   const allMonths = getAllMonthMoments(startMoment, futureMonthsToScrape);
 
   await loadCategories(page);
+  const homePageCards = await loadHomePageData(page);
 
   let allResults: Record<string, Transaction[]> = {};
   for (let i = 0; i < allMonths.length; i += 1) {
@@ -324,7 +367,7 @@ async function fetchTransactions(page: Page, options: ScraperOptions) {
     allResults[accountNumber] = txns;
   });
 
-  return allResults;
+  return { allResults, homePageCards };
 }
 
 function getPossibleLoginResults(page: Page): PossibleLoginResults {
@@ -387,11 +430,15 @@ class MaxScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
   }
 
   async fetchData() {
-    const results = await fetchTransactions(this.page, this.options);
-    const accounts = Object.keys(results).map(accountNumber => {
+    const { allResults, homePageCards } = await fetchTransactions(this.page, this.options);
+    const accounts: TransactionsAccount[] = Object.keys(allResults).map(accountNumber => {
+      const card = homePageCards.get(accountNumber);
       return {
         accountNumber,
-        txns: results[accountNumber],
+        txns: allResults[accountNumber],
+        balance: card ? getCardBalance(card) : undefined,
+        balanceDate: card ? getCardBalanceDate(card) : undefined,
+        cardFrame: card?.CreditLimit ?? undefined,
       };
     });
 


### PR DESCRIPTION
Related to https://github.com/eshaham/israeli-bank-scrapers/pull/1138

This PR also adds the frame feature to Max cards. Adds the new fields `balanceDate` and `cardFrame`, representing the next billing date and the total frame for the card type, respectively. If there's a difference between bank-issued cards and Max-issued cards, like with Cal, I'm unaware of this, as I only have Max-issued cards.

Test results:
```
{
  "success": true,
  "accounts": [
    {
      "accountNumber": "XXXX",
      "txns": [
        {
          "type": "normal",
          "date": "2026-07-02T21:00:00.000Z",
          "processedDate": "2026-07-06T21:00:00.000Z",
          "originalAmount": -183.97,
          "originalCurrency": "ILS",
          "chargedAmount": -183.97,
          "chargedCurrency": "ILS",
          "description": "STEAM PURCHASE         SEATTLE       DE",
          "memo": "חיוב עסקת חו\"ל בש\"ח ",
          "category": "פנאי, בידור וספורט",
          "identifier": "XXXXXXXXXXXXXXXX",
          "status": "completed"
        }
      ],
      "balance": -183.97,
      "balanceDate": "2026-08-02T00:00:00",
      "cardFrame": 8000
    }
  ]
}
```