### PR TITLE
feat(discount): add Discount Bank for Business (SME) scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently only the following banks are supported:
 - Bank Hapoalim (thanks [@sebikaplun](https://github.com/sebikaplun))
 - Leumi Bank (thanks [@esakal](https://github.com/esakal))
 - Discount Bank
+- Discount Bank for Business (SME)
 - Mercantile Bank (thanks [@ezzatq](https://github.com/ezzatq) and [@kfirarad](https://github.com/kfirarad)))
 - Mizrahi Bank (thanks [@baruchiro](https://github.com/baruchiro))
 - Otsar Hahayal Bank (thanks [@matanelgabsi](https://github.com/matanelgabsi))
@@ -296,6 +297,16 @@ const credentials = {
   id: <user identification number>,
   password: <user password>,
   num: <user identificaiton code>
+};
+```
+This scraper supports fetching transaction from up to one year (minus 1 day).
+
+## Discount Business scraper
+This scraper logs into the Discount Bank for Business (SME) site and expects the following credentials object:
+```node
+const credentials = {
+  id: <user identification number>,
+  password: <user password>
 };
 ```
 This scraper supports fetching transaction from up to one year (minus 1 day).

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,6 +12,7 @@ export enum CompanyTypes {
   max = 'max',
   otsarHahayal = 'otsarHahayal',
   discount = 'discount',
+  discountBusiness = 'discountBusiness',
   mercantile = 'mercantile',
   mizrahi = 'mizrahi',
   leumi = 'leumi',
@@ -39,6 +40,10 @@ export const SCRAPERS = {
   [CompanyTypes.discount]: {
     name: 'Discount Bank',
     loginFields: ['id', PASSWORD_FIELD, 'num'],
+  },
+  [CompanyTypes.discountBusiness]: {
+    name: 'Discount Bank Business',
+    loginFields: ['id', PASSWORD_FIELD],
   },
   [CompanyTypes.mercantile]: {
     name: 'Mercantile Bank',

--- a/src/scrapers/discount-business.test.ts
+++ b/src/scrapers/discount-business.test.ts
@@ -1,0 +1,53 @@
+import { SCRAPERS } from '../definitions';
+import { exportTransactions, extendAsyncTimeout, getTestsConfig, maybeTestCompanyAPI } from '../tests/tests-utils';
+import { LoginResults } from './base-scraper-with-browser';
+import DiscountBusinessScraper from './discount-business';
+
+const COMPANY_ID = 'discountBusiness'; // TODO this property should be hard-coded in the provider
+const testsConfig = getTestsConfig();
+
+describe('Discount business scraper', () => {
+  beforeAll(() => {
+    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+  });
+
+  test('should expose login fields in scrapers constant', () => {
+    expect(SCRAPERS.discountBusiness).toBeDefined();
+    expect(SCRAPERS.discountBusiness.loginFields).toContain('id');
+    expect(SCRAPERS.discountBusiness.loginFields).toContain('password');
+  });
+
+  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
+    'should fail on invalid user/password"',
+    async () => {
+      const options = {
+        ...testsConfig.options,
+        companyId: COMPANY_ID,
+      };
+
+      const scraper = new DiscountBusinessScraper(options);
+
+      const result = await scraper.scrape({ id: 'e10s12', password: '3f3ss3d' });
+
+      expect(result).toBeDefined();
+      expect(result.success).toBeFalsy();
+      expect(result.errorType).toBe(LoginResults.InvalidPassword);
+    },
+  );
+
+  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
+    const options = {
+      ...testsConfig.options,
+      companyId: COMPANY_ID,
+    };
+
+    const scraper = new DiscountBusinessScraper(options);
+    const result = await scraper.scrape(testsConfig.credentials.discountBusiness);
+    expect(result).toBeDefined();
+    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
+    expect(error).toBe('');
+    expect(result.success).toBeTruthy();
+
+    exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});

--- a/src/scrapers/discount-business.ts
+++ b/src/scrapers/discount-business.ts
@@ -1,0 +1,57 @@
+import { waitUntilElementFound } from '../helpers/elements-interactions';
+import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from './base-scraper-with-browser';
+import { BASE_URL, fetchAccountData, navigateOrErrorLabel } from './discount';
+
+type ScraperSpecificCredentials = { id: string; password: string };
+
+function getPossibleLoginResults(): PossibleLoginResults {
+  const urls: PossibleLoginResults = {};
+  urls[LoginResults.Success] = [
+    // the business site is deployed as /apollo/business, /apollo/business2, /apollo/business3 etc.
+    new RegExp(`^${BASE_URL}/apollo/business\\d*/`),
+  ];
+  urls[LoginResults.InvalidPassword] = [
+    // a failed login attempt keeps the SPA on the login route and shows an inline error
+    `${BASE_URL}/login/#/LOGIN_PAGE_SME`,
+    `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE_SME`,
+  ];
+  urls[LoginResults.ChangePassword] = [
+    `${BASE_URL}/login/#/PWD_RENEW`,
+    `${BASE_URL}/apollo/core/templates/lobby/masterPage.html#/PWD_RENEW`,
+  ];
+  return urls;
+}
+
+function createLoginFields(credentials: ScraperSpecificCredentials) {
+  return [
+    { selector: '#tzId', value: credentials.id },
+    { selector: '#tzPassword', value: credentials.password },
+  ];
+}
+
+class DiscountBusinessScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
+  getLoginOptions(credentials: ScraperSpecificCredentials) {
+    return {
+      loginUrl: `${BASE_URL}/login/#/LOGIN_PAGE_SME`,
+      checkReadiness: async () => waitUntilElementFound(this.page, '#tzId'),
+      fields: createLoginFields(credentials),
+      submitButtonSelector: '.sendBtn',
+      postAction: async () => navigateOrErrorLabel(this.page),
+      possibleResults: getPossibleLoginResults(),
+    };
+  }
+
+  async fetchData() {
+    // the business SPA keeps redirecting for a short while after a successful login;
+    // a fetch injected during one of those navigations gets its execution context
+    // destroyed, so let the page settle first
+    await this.page.waitForNetworkIdle({ idleTime: 1000, timeout: 30000 }).catch(() => {});
+    return fetchAccountData(
+      this.page,
+      this.options,
+      'userAccounts/bsUserAccountsData?FetchAccountsNickName=true&FirstTimeEntry=false',
+    );
+  }
+}
+
+export default DiscountBusinessScraper;

--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -9,7 +9,7 @@ import { BaseScraperWithBrowser, LoginResults, type PossibleLoginResults } from 
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
 
-const BASE_URL = 'https://start.telebank.co.il';
+export const BASE_URL = 'https://start.telebank.co.il';
 const DATE_FORMAT = 'YYYYMMDD';
 
 interface ScrapedTransaction {
@@ -75,10 +75,16 @@ function convertTransactions(
   });
 }
 
-async function fetchAccountData(page: Page, options: ScraperOptions): Promise<ScraperScrapingResult> {
+export async function fetchAccountData(
+  page: Page,
+  options: ScraperOptions,
+  // The business (SME) portal exposes accounts under a different path than the retail site,
+  // though the response shape and the transactions endpoint are identical.
+  accountsEndpoint = 'userAccountsData',
+): Promise<ScraperScrapingResult> {
   const apiSiteUrl = `${BASE_URL}/Titan/gatewayAPI`;
 
-  const accountDataUrl = `${apiSiteUrl}/userAccountsData`;
+  const accountDataUrl = `${apiSiteUrl}/${accountsEndpoint}`;
   const accountInfo = await fetchGetWithinPage<ScrapedAccountData>(page, accountDataUrl);
 
   if (!accountInfo) {
@@ -133,7 +139,7 @@ async function fetchAccountData(page: Page, options: ScraperOptions): Promise<Sc
   return accountData;
 }
 
-async function navigateOrErrorLabel(page: Page) {
+export async function navigateOrErrorLabel(page: Page) {
   try {
     await waitForNavigation(page);
   } catch (e) {

--- a/src/scrapers/factory.ts
+++ b/src/scrapers/factory.ts
@@ -5,6 +5,7 @@ import BehatsdaaScraper from './behatsdaa';
 import BeinleumiScraper from './beinleumi';
 import BeyahadBishvilhaScraper from './beyahad-bishvilha';
 import DiscountScraper from './discount';
+import DiscountBusinessScraper from './discount-business';
 import HapoalimScraper from './hapoalim';
 import { type Scraper, type ScraperCredentials, type ScraperOptions } from './interface';
 import IsracardScraper from './isracard';
@@ -32,6 +33,8 @@ export default function createScraper(options: ScraperOptions): Scraper<ScraperC
       return new MizrahiScraper(options);
     case CompanyTypes.discount:
       return new DiscountScraper(options);
+    case CompanyTypes.discountBusiness:
+      return new DiscountBusinessScraper(options);
     case CompanyTypes.mercantile:
       return new MercantileScraper(options);
     case CompanyTypes.otsarHahayal:

--- a/src/tests/.tests-config.tpl.js
+++ b/src/tests/.tests-config.tpl.js
@@ -19,6 +19,7 @@ module.exports = {
     // leumi: { username: '', password: '' },
     // hapoalimBeOnline: { userCode: '', password: '' },
     // discount: { id: '', password: '', num: '' },
+    // discountBusiness: { id: '', password: '' },
     // otsarHahayal: { username: '', password: '' },
     // max: { username: '', password: '' },
     // visaCal: { username: '', password: '' },


### PR DESCRIPTION
Add a discountBusiness scraper for the Discount Bank business (SME) portal. It reuses the existing Discount retail scraper logic: BASE_URL, navigateOrErrorLabel and fetchAccountData are now exported from discount.ts, and fetchAccountData accepts an optional accounts endpoint since the business portal serves accounts from bsUserAccountsData instead of userAccountsData (the transactions endpoint and response shape are identical).

The business SPA keeps redirecting briefly after a successful login, so fetchData waits for the network to go idle before injecting the accounts fetch.

Includes login result detection for the SME login routes (LOGIN_PAGE_SME, PWD_RENEW), tests, README documentation and a tests-config template entry.

Closes #1116