### PR TITLE
fix(release): install npm 11 into a separate prefix to avoid self-upgrade failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,14 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@^11.5.1
+        # Node 22 bundles npm 10.9.7, which cannot self-upgrade to npm 11:
+        # `npm install -g npm@11` overwrites the running npm mid-reify and then
+        # fails with "Cannot find module 'promise-retry'". Install npm 11 into a
+        # separate prefix and prepend it to PATH instead of overwriting the
+        # bundled npm.
+        run: |
+          npm install -g npm@^11.5.1 --prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
       - name: Verify npm version
         run: |
           echo "Node version: $(node -v)"


### PR DESCRIPTION
## Problem

The Release workflow has been failing since #1141 at the **"Upgrade npm for OIDC support"** step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

**Root cause:** Node 22 (pinned in `.nvmrc` as `v22.22.2`) bundles npm `10.9.7`. Running `npm install -g npm@^11.5.1` makes npm upgrade **itself** in the same global prefix. Mid-`reify`, npm overwrites its own `node_modules`, and a subsequent lazy `require('promise-retry')` (in `@npmcli/arborist`'s `rebuild.js`, reached via `reify-output` → `libnpmfund`) then fails because the module has already been swapped out. This is a known npm self-upgrade race; the previous attempts (#1143 bumping Node, #1145 pinning the npm version) didn't address it because they kept the in-place self-overwrite.

## Fix

Install npm 11 into a **separate prefix** and prepend it to `PATH` instead of letting the bundled npm overwrite itself:

```yaml
- name: Upgrade npm for OIDC support
  run: |
    npm install -g npm@^11.5.1 --prefix "$HOME/.npm-global"
    echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
```

Because the new npm lands in its own prefix, the running npm never overwrites its own files, so the `promise-retry` race can't happen. Node stays on the `.nvmrc`-pinned version (22) and npm becomes 11.x for trusted-publishing / OIDC provenance.

## Verification

Reproduced and verified on real GitHub-hosted runners (via a temporary `on: push` workflow, since removed):

- **Reproduce job** (runs the original command): `Reproduced: bundled npm self-upgrade failed as expected (exit 1)` ✅
- **Verify-fix job** (runs the separate-prefix install):
  ```
  node: v22.22.2
  npm:  11.18.0
  npm 11 is active
  node is still 22
  ```
  ✅

Also reproduced locally on the identical Node `v22.22.2` / npm `10.9.7` toolchain: the in-place self-upgrade fails with the exact `promise-retry` error, while the separate-prefix install succeeds and yields npm `11.18.0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn2q8dw3JCGnNakPsDM4hE)_