### PR TITLE
fix(visa-cal): more credit card balance issues

### DIFF
--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -178,6 +178,7 @@ interface IssuedCardsGroup {
   nextTotalDebitForAccount?: number;
   nextTotalDebitDateForAccount?: string | null;
   frameLimitForCardAmount?: number;
+  fictiveMaxAccAmt?: number;
   cardLevelFrames?: CardLevelFrame[];
 }
 
@@ -531,17 +532,25 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     );
 
     let frame: CardLevelFrame | undefined;
-    let cardType: CardType;
+    let cardType: CardType = CardType.CompanyIssued;
     let accountGroup: IssuedCardsGroup | undefined;
 
     if (bankIssuedFrame) {
       frame = bankIssuedFrame;
       cardType = CardType.BankIssued;
       accountGroup = frames.result?.bankIssuedCards;
-    } else {
+    } else if (calIssuedFrame) {
       frame = calIssuedFrame;
       cardType = CardType.CompanyIssued;
       accountGroup = frames.result?.calIssuedCards;
+    } else if (frames.result?.bankIssuedCards) {
+      // No card-level frame found, but account has bankIssuedCards data
+      cardType = CardType.BankIssued;
+      accountGroup = frames.result.bankIssuedCards;
+    } else if (frames.result?.calIssuedCards) {
+      // No card-level frame found, but account has calIssuedCards data
+      cardType = CardType.CompanyIssued;
+      accountGroup = frames.result.calIssuedCards;
     }
 
     debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
@@ -608,7 +617,14 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
         : transactions;
 
     // Use card-level balance if available, otherwise fall back to account-level balance
-    const balanceAmount = frame?.nextTotalDebit ?? accountGroup?.nextTotalDebitForAccount;
+    // As a last resort, calculate balance from frame limit - fictive max account amount
+    const balanceAmount =
+      frame?.nextTotalDebit ??
+      accountGroup?.nextTotalDebitForAccount ??
+      (accountGroup?.frameLimitForCardAmount != null && accountGroup?.fictiveMaxAccAmt != null
+        ? accountGroup.frameLimitForCardAmount - accountGroup.fictiveMaxAccAmt
+        : undefined);
+
     const result: TransactionsAccount = {
       txns,
       balance: balanceAmount != null ? -balanceAmount : undefined,

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -221,6 +221,22 @@ function isCardPendingTransactionDetails(
   return (result as CardPendingTransactionDetails).result !== undefined;
 }
 
+function getBalanceAmount(frame: CardLevelFrame | undefined, accountGroup: IssuedCardsGroup | undefined) {
+  if (frame?.nextTotalDebit != null) {
+    return frame.nextTotalDebit;
+  }
+
+  if (accountGroup?.nextTotalDebitForAccount != null) {
+    return accountGroup.nextTotalDebitForAccount;
+  }
+
+  if (accountGroup?.frameLimitForCardAmount == null || accountGroup.fictiveMaxAccAmt == null) {
+    return undefined;
+  }
+
+  return accountGroup.frameLimitForCardAmount - accountGroup.fictiveMaxAccAmt;
+}
+
 async function getLoginFrame(page: Page) {
   let frame: Frame | null = null;
   debug('wait until login frame found');
@@ -616,14 +632,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
         ? filterOldTransactions(transactions, moment(startDate), this.options.combineInstallments || false)
         : transactions;
 
-    // Use card-level balance if available, otherwise fall back to account-level balance
-    // As a last resort, calculate balance from frame limit - fictive max account amount
-    const balanceAmount =
-      frame?.nextTotalDebit ??
-      accountGroup?.nextTotalDebitForAccount ??
-      (accountGroup?.frameLimitForCardAmount != null && accountGroup?.fictiveMaxAccAmt != null
-        ? accountGroup.frameLimitForCardAmount - accountGroup.fictiveMaxAccAmt
-        : undefined);
+    const balanceAmount = getBalanceAmount(frame, accountGroup);
 
     const result: TransactionsAccount = {
       txns,


### PR DESCRIPTION
Fixes Cal credit card balances and frames not loading for some people because of how the data in their account is structured.

Local test results:
```
{
  "success": true,
  "accounts": [
    {
      "txns": [],
      "balance": -327,
      "balanceDate": "2026-09-02T00:00:00",
      "accountNumber": "9106",
      "cardType": "bankIssued",
      "cardFrame": 7500
    }
  ]
}
```

Debug logs
```
  israeli-bank-scrapers:visa-cal   result: {
  israeli-bank-scrapers:visa-cal     calIssuedCards: null,
  israeli-bank-scrapers:visa-cal     bankIssuedCards: {
  israeli-bank-scrapers:visa-cal       fictiveMaxAccAmt: 7075,
  israeli-bank-scrapers:visa-cal       frameLimitForCardAmount: 7500,
  israeli-bank-scrapers:visa-cal       totalUsageAmountForAccountManagementLevel: 327,
  israeli-bank-scrapers:visa-cal       usageAmountForExternalCards: 98,
  israeli-bank-scrapers:visa-cal       nextTotalDebitDateForAccount: '2026-09-02T00:00:00',
  israeli-bank-scrapers:visa-cal       nextTotalDebitForAccount: 327,
  israeli-bank-scrapers:visa-cal       currencyCode: 3,
  israeli-bank-scrapers:visa-cal       currencySymbol: '₪',
  israeli-bank-scrapers:visa-cal       summary: [Object],
  israeli-bank-scrapers:visa-cal       accountComments: [Array],
  israeli-bank-scrapers:visa-cal       accountLevelFrames: [],
  israeli-bank-scrapers:visa-cal       cardLevelFrames: [],
  israeli-bank-scrapers:visa-cal       accountExceptionalCards: [Array]
  israeli-bank-scrapers:visa-cal     }
  israeli-bank-scrapers:visa-cal   },
  israeli-bank-scrapers:visa-cal   statusDescription: null,
  israeli-bank-scrapers:visa-cal   statusTitle: null,
  israeli-bank-scrapers:visa-cal   statusCode: 1,
  israeli-bank-scrapers:visa-cal } +72ms
```