### PR TITLE
fix(leumi): repair invalid-password detection on redesigned logon page

### DIFF
--- a/src/scrapers/leumi.ts
+++ b/src/scrapers/leumi.ts
@@ -19,7 +19,8 @@ const SAVINGS_URL = `${BASE_URL}/uiapiproxy/v1/digital-retails/mobile/accounts/1
 
 const DATE_FORMAT = 'DD.MM.YY';
 const ACCOUNT_BLOCKED_MSG = 'המנוי חסום';
-const INVALID_PASSWORD_MSG = 'אחד או יותר מפרטי ההזדהות שמסרת שגויים. ניתן לנסות שוב';
+// Leumi rewords the suffix of this message occasionally (שמסרת/שהוקלדו); match the stable prefix only.
+const INVALID_PASSWORD_MSG = 'אחד או יותר מפרטי ההזדהות';
 const CHANGE_PASSWORD_MODAL_SELECTOR = 'form input[name="newPwd"]';
 
 interface SavingsDepositItem {
@@ -66,11 +67,10 @@ function getPossibleLoginResults() {
         if (!options || !options.page) {
           throw new Error('missing page options argument');
         }
-        const errorMessage = await pageEvalAll(options.page, 'svg#Capa_1', '', element => {
-          return (element[0]?.parentElement?.children[1] as HTMLDivElement)?.innerText;
-        });
-
-        return errorMessage?.startsWith(INVALID_PASSWORD_MSG);
+        // The svg#Capa_1 icon anchor no longer exists on the redesigned
+        // logon page; detect the failure message anywhere in the page text.
+        const bodyText = await options.page.evaluate(() => document.body?.innerText ?? '');
+        return bodyText.includes(INVALID_PASSWORD_MSG);
       },
     ],
     [LoginResults.AccountBlocked]: [
@@ -329,7 +329,7 @@ async function waitForPostLogin(page: Page): Promise<void> {
   await Promise.race([
     waitUntilElementFound(page, 'a[title="דלג לחשבון"]', true, 60000),
     waitUntilElementFound(page, 'div.main-content', false, 60000),
-    page.waitForSelector(`xpath//div[contains(string(),"${INVALID_PASSWORD_MSG}")]`),
+    page.waitForSelector(`xpath///div[contains(string(),"${INVALID_PASSWORD_MSG}")]`),
     waitUntilElementFound(page, CHANGE_PASSWORD_MODAL_SELECTOR, true, 60000),
   ]);
 }


### PR DESCRIPTION
# Fix Leumi invalid-password detection on the redesigned logon page

## Problem

With valid selectors up to date otherwise, entering wrong credentials on the Leumi scraper currently ends in `UNKNOWN_ERROR` / a selector timeout instead of `INVALID_PASSWORD`. Three independent bugs in `src/scrapers/leumi.ts` combine to cause this:

### 1. `INVALID_PASSWORD_MSG` no longer matches the live page

Leumi reworded the error message. The constant expects:

> אחד או יותר מפרטי ההזדהות **שמסרת** שגויים. ניתן לנסות שוב

but the logon page now renders:

> אחד או יותר מפרטי ההזדהות **שהוקלדו** שגויים...

**Fix:** match only the stable prefix `אחד או יותר מפרטי ההזדהות`, so future rewording of the suffix doesn't break detection again.

### 2. `waitForPostLogin` xpath prefix never matches

```ts
page.waitForSelector(`xpath//div[contains(string(),"${INVALID_PASSWORD_MSG}")]`)
```

Puppeteer's `xpath/` prefix treats everything after `xpath/` as the expression, so `xpath//div[...]` is parsed as the **absolute** path `/div[...]` — which can never match (the document root's child is `<html>`, not `<div>`). The invalid-password branch of the `Promise.race` in `waitForPostLogin` could therefore never win, and bad credentials surfaced as a 60s timeout. `clickByXPath` calls elsewhere in this file already use the correct `xpath///` form.

**Fix:** `xpath//div[...]` → `xpath///div[...]` (descendant axis).

### 3. `InvalidPassword` login-result detector anchored on a removed element

The detector located the error text by traversing the DOM from `svg#Capa_1`:

```ts
const errorMessage = await pageEvalAll(options.page, 'svg#Capa_1', '', element => {
  return (element[0]?.parentElement?.children[1] as HTMLDivElement)?.innerText;
});
return errorMessage?.startsWith(INVALID_PASSWORD_MSG);
```

That icon no longer exists on the redesigned logon page, so even once the wait resolves, the result is classified as `UNKNOWN_ERROR` instead of `INVALID_PASSWORD`.

**Fix:** detect the message via `document.body.innerText.includes(INVALID_PASSWORD_MSG)` — resilient to markup changes around the message.

## Verification

- Reproduced against the live `https://hb2.bankleumi.co.il/authenticate/logon` page with deliberately wrong credentials: before the fix, scraping fails with a selector timeout / `GENERIC` error; after the fix, it returns `LoginResults.InvalidPassword` end-to-end.
- A Puppeteer probe of the live logon page confirmed the error text renders inside plain nested `<div>`s (no `svg#Capa_1` present, no shadow DOM).
- `npm run type-check`, `eslint`, and `prettier --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
