### PR TITLE
docs(pr-safety-review): add conversation-state check

### DIFF
--- a/.claude/skills/pr-safety-review/SKILL.md
+++ b/.claude/skills/pr-safety-review/SKILL.md
@@ -19,6 +19,20 @@ Don't review from the PR title/description alone — authors describe intent, no
 
 If given only a PR number/URL, resolve owner/repo from the current git remote unless told otherwise.
 
+### Conversation state — is this even ready to be (re-)reviewed?
+
+Before spending effort on the three code checks, work out where the PR actually sits in its own conversation. A full fresh review is wasted effort — and misleading to the reviewer — if the PR is simply sitting idle waiting on the author, or if a prior reviewer's ask was never actually addressed despite the branch looking "active."
+
+Fetch `get_comments`, `get_review_comments` (threads), and `get_commits`, and line them up by timestamp. Then:
+
+1. **Filter out noise.** Discard bot housekeeping (stale-bot, labeler comments), the PR author's own comments (pings, "any update?", apologies for delay), and reactions/threads with no actionable ask. What's left is the substantive asks: a maintainer/collaborator requesting a change (split the PR, rebase, fix X, provide evidence for Y), or a review-bot/human finding on a specific line.
+
+2. **Find the most recent substantive ask and compare its timestamp to the most recent commit:**
+   - **No commit since that ask** → say so plainly, and say it *first*, before anything else. This is a strong signal the PR is stalled waiting on the author, not something to hand back a fresh SAFE/RISKY/BREAKING verdict on as if it just landed. Name who asked, what they asked for, and since when nothing has moved.
+   - **Commits exist since that ask** → don't assume they're a response just because they exist. Check whether the new commits actually touch what was asked (same file/function for a code fix; an actual rebase for a "please rebase" ask; the PR literally split for a "split this into N PRs" ask — check `mergeable_state` too, since "please rebase" isn't satisfied by unrelated new commits on top of an still-unresolved conflict). If the new activity is unrelated to the ask, say so explicitly: the ask is still open despite the branch looking active. If it does address the ask, treat it as being actively iterated on and proceed normally.
+
+3. **Apply the same logic per review-comment thread**, not just to the top-level conversation. GitHub marks a thread `is_outdated` once the diff at that location has changed since the comment — but that only means the code moved, not that the concern was resolved. Read the current code at that location yourself and decide whether it actually addresses the finding, rather than trusting `is_outdated`/`is_resolved` at face value. A thread can be simultaneously "outdated" and still perfectly valid (the code moved but the same bug is still there), or outdated and genuinely fixed by later work — only reading the current lines tells you which.
+
 ## Step 2 — Run the three checks
 
 Do these as an analysis pass over the diff you just read, not as separate tool-heavy investigations. Each check below produces zero or more findings; a clean check produces none, and that's a fine outcome — don't invent a finding to look thorough.
@@ -61,7 +75,9 @@ Isolation from *failure* isn't the only cost worth naming, though — it's just 
 
 ## Step 3 — Output
 
-Keep this to what a reviewer reads in ten seconds plus a skimmable list. Use exactly this shape:
+Keep this to what a reviewer reads in ten seconds plus a skimmable list. If the conversation-state check above found that nothing has changed since the last substantive reviewer ask, lead with that — one or two plain-text sentences, before the verdict block, naming who asked, for what, and since when. That's a process fact, not a code finding, so it never becomes a bullet inside the verdict. Still produce the verdict block after it if the code itself is worth characterizing, but don't let it read like a routine "go ahead and merge" — the staleness is the headline.
+
+Otherwise, use exactly this shape:
 
 ```
 ## Verdict: SAFE | RISKY | BREAKING

--- a/.claude/skills/pr-safety-review/evals/evals.json
+++ b/.claude/skills/pr-safety-review/evals/evals.json
@@ -4,9 +4,9 @@
     {
       "id": 1,
       "name": "visa-cal-safe-fallback-fix",
-      "prompt": "Can you review https://github.com/eshaham/israeli-bank-scrapers/pull/1153 for me? I don't have time to dig into every PR myself — just give me the important part before I approve.",
+      "prompt": "I made this fix for Cal credit card balances/frames not loading for some accounts. The diff is at evals/fixtures/visa-cal-diff.txt relative to the skill directory -- read it and review it the way you would a real PR diff. I don't have time to dig into every PR myself -- just give me the important part before I approve.\n\nLocal debug log from testing (this is the input shape the new fallback logic sees for one affected account):\n```\nresult: {\n  calIssuedCards: null,\n  bankIssuedCards: {\n    fictiveMaxAccAmt: 7075,\n    frameLimitForCardAmount: 7500,\n    totalUsageAmountForAccountManagementLevel: 327,\n    usageAmountForExternalCards: 98,\n    nextTotalDebitDateForAccount: '2026-09-02T00:00:00',\n    nextTotalDebitForAccount: 327,\n    currencyCode: 3,\n    currencySymbol: '₪',\n    accountLevelFrames: [],\n    cardLevelFrames: [],\n  }\n},\nstatusCode: 1\n```",
       "expected_output": "A short verdict block (SAFE or RISKY are both defensible here -- see reasoning below). The diff's first two fallback branches (bank frame found, cal frame found) are byte-for-byte unchanged from before, so a good review should say so explicitly. The two new branches only fire when neither of those matched: one adds a bankIssuedCards-before-calIssuedCards priority check that changes which account group is used *if* an account can ever have both groups populated at once for a single-card request -- a real, if unconfirmed, compat risk worth flagging as RISKY with that reachability caveat spelled out (SAFE is only correct if the response explicitly argues the per-card request shape rules this out). The other new branch is a last-resort balance formula (frameLimitForCardAmount - fictiveMaxAccAmt) that the author's own posted debug log never actually exercises (it hit the branch above it instead, per that log's nextTotalDebitForAccount already being present) -- that should be flagged as unverified regardless of the overall verdict. Output must be short (verdict + a handful of tagged bullets), not a long essay.",
-      "files": [],
+      "files": ["evals/fixtures/visa-cal-diff.txt"],
       "expectations": [
         "The verdict line is SAFE or RISKY (not BREAKING) -- either is acceptable as long as the reasoning below is present",
         "There is a [compat] tagged finding that explicitly states the bank-frame-found and cal-frame-found branches are unchanged from before",
@@ -18,9 +18,9 @@
     {
       "id": 2,
       "name": "isracard-amex-graceful-degradation",
-      "prompt": "What about https://github.com/eshaham/israeli-bank-scrapers/pull/1154 in the same repo -- does it introduce a change to existing behavior?",
+      "prompt": "Does this diff at evals/fixtures/isracard-amex-diff.txt (relative to the skill directory) introduce a change to existing behavior? Read it and review it the way you would a real PR diff against this repo.",
       "expected_output": "A short SAFE verdict. Should note under [compat] that balance/balanceDate/cardFrame were already optional fields on TransactionsAccount (added in an earlier PR) that were always undefined for isracard/amex, so populating them now isn't a break for existing consumers. Should note under [feature-safety] that the new card-list page fetch (fetchCardBalances) is wrapped in try/catch and degrades to an empty Map / undefined fields on failure rather than throwing, and that it runs as the last step of fetchData so no later core logic depends on the page's prior state. Should be short, not exhaustive.",
-      "files": [],
+      "files": ["evals/fixtures/isracard-amex-diff.txt"],
       "expectations": [
         "The verdict line reads SAFE",
         "There is a [compat] tagged finding noting balance/cardFrame/balanceDate were already optional and previously undefined for isracard/amex, so no existing consumer sees a breaking shape change",

--- a/.claude/skills/pr-safety-review/evals/fixtures/isracard-amex-diff.txt
+++ b/.claude/skills/pr-safety-review/evals/fixtures/isracard-amex-diff.txt
@@ -1,0 +1,299 @@
+diff --git a/src/scrapers/amex.test.ts b/src/scrapers/amex.test.ts
+index 695415c9e..02834387e 100644
+--- a/src/scrapers/amex.test.ts
++++ b/src/scrapers/amex.test.ts
+@@ -36,7 +36,7 @@ describe('AMEX legacy scraper', () => {
+     },
+   );
+
+-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
++  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions and balances', async () => {
+     const options = {
+       ...testsConfig.options,
+       companyId: COMPANY_ID,
+@@ -48,6 +48,10 @@ describe('AMEX legacy scraper', () => {
+     const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
+     expect(error).toBe('');
+     expect(result.success).toBeTruthy();
++    result.accounts?.forEach(account => {
++      expect(account.balance).toBeDefined();
++      expect(account.cardFrame).toBeDefined();
++    });
+
+     exportTransactions(COMPANY_ID, result.accounts || []);
+   });
+diff --git a/src/scrapers/base-isracard-amex.test.ts b/src/scrapers/base-isracard-amex.test.ts
+new file mode 100644
+index 000000000..0ea9f23d4
+--- /dev/null
++++ b/src/scrapers/base-isracard-amex.test.ts
+@@ -0,0 +1,89 @@
++import { parseCardListBalances } from './base-isracard-amex';
++
++describe('parseCardListBalances', () => {
++  test('parses card balance, balance date, and credit frame from the card-list page', () => {
++    const balances = parseCardListBalances(`
++      עבור כרטיס שמסתיים ב7392
++      ניצלת עד כה 9,564.99 מתוך מסגרת האשראי 15,500 נכון לתאריך 10/08/2026
++    `);
++
++    expect(balances.get('7392')).toEqual({
++      balance: -9564.99,
++      balanceDate: '2026-08-10T00:00:00',
++      cardFrame: 15500,
++    });
++  });
++
++  test('skips card sections without a complete balance', () => {
++    const balances = parseCardListBalances('עבור כרטיס שמסתיים ב7392');
++
++    expect(balances.size).toBe(0);
++  });
++
++  test('derives an Isracard card balance from its credit frame and remaining credit', () => {
++    const balances = parseCardListBalances(`
++      מסטרקארד
++      7392
++      ₪9,564.99 לחיוב ב-10.08
++      מסגרת: ₪15,500
++      נותר לניצול: ₪5,935.01
++    `);
++
++    expect(balances.get('7392')).toEqual({
++      balance: -9564.99,
++      balanceDate: '2026-08-10T00:00:00',
++      cardFrame: 15500,
++    });
++  });
++
++  test('parses an Isracard card without a displayed billing date', () => {
++    const balances = parseCardListBalances(`
++      מסטרקארד
++      7392 מבוטל
++      מסגרת: ₪15,500
++      נותר לניצול: ₪15,500
++    `);
++
++    expect(balances.get('7392')).toEqual({
++      balance: 0,
++      cardFrame: 15500,
++    });
++  });
++
++  test('uses a single displayed Isracard billing date for cards without one', () => {
++    const balances = parseCardListBalances(`
++      מסטרקארד
++      7392
++      ₪9,564.99 לחיוב ב-10.09
++      מסגרת: ₪15,500
++      נותר לניצול: ₪5,935.01
++      1234
++      מסגרת: ₪5,000
++      נותר לניצול: ₪4,328.00
++    `);
++
++    expect(balances.get('1234')).toEqual({
++      balance: -672,
++      balanceDate: '2026-09-10T00:00:00',
++      cardFrame: 5000,
++    });
++  });
++
++  test('does not use a shared Isracard billing date for a zero-frame card', () => {
++    const balances = parseCardListBalances(`
++      מסטרקארד
++      7392
++      ₪9,564.99 לחיוב ב-10.09
++      מסגרת: ₪15,500
++      נותר לניצול: ₪5,935.01
++      1234 מבוטל
++      מסגרת: ₪0
++      נותר לניצול: ₪0.00
++    `);
++
++    expect(balances.get('1234')).toEqual({
++      balance: 0,
++      cardFrame: 0,
++    });
++  });
++});
+diff --git a/src/scrapers/base-isracard-amex.ts b/src/scrapers/base-isracard-amex.ts
+index 564f061c9..c4af00829 100644
+--- a/src/scrapers/base-isracard-amex.ts
++++ b/src/scrapers/base-isracard-amex.ts
+@@ -30,12 +30,26 @@ const ID_TYPE = '1';
+ const INSTALLMENTS_KEYWORD = 'תשלום';
+
+ const DATE_FORMAT = 'DD/MM/YYYY';
++const BALANCE_DATE_OUTPUT_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss';
++
++const CARD_LIST_PAGE_PATH = '/personalarea/cardlist/?WebPage=true';
++const CARD_LIST_BALANCE_READY_MARKERS = ['עבור כרטיס שמסתיים ב', 'נותר לניצול:'];
++const CARD_SUFFIX_PATTERN = '(\\d{4})';
++const AMEX_CARD_SECTION_SEPARATOR = new RegExp('עבור כרטיס שמסתיים ב\\s*');
++const AMEX_CARD_BALANCE_PATTERN =
++  /ניצלת עד כה\s*([\d,.]+)\s*(?:₪)?\s*מתוך מסגרת האשראי\s*([\d,.]+).*?נכון לתאריך\s*:?[\s]*(\d{2}[/\.\-]\d{2}[/\.\-]\d{4})/s;
++const ISRACARD_CARD_BALANCE_PATTERN = new RegExp(
++  `${CARD_SUFFIX_PATTERN}[\\s\\S]*?מסגרת:\\s*₪?\\s*([\\d,.]+)[\\s\\S]*?נותר לניצול:\\s*₪?\\s*([\\d,.]+)`,
++  'g',
++);
++const ISRACARD_CARD_BALANCE_DATE_PATTERN = /לחיוב ב-(\d{2}[/.\-]\d{2})/;
+
+ const debug = getDebug('base-isracard-amex');
+
+ type CompanyServiceOptions = {
+   servicesUrl: string;
+   companyCode: string;
++  cardListPageUrl: string;
+ };
+
+ type ScrapedAccountsWithIndex = Record<string, TransactionsAccount & { index: number }>;
+@@ -108,6 +122,72 @@ interface ScrapedTransactionData {
+   >;
+ }
+
++type ScrapedCardBalance = {
++  balance: number;
++  balanceDate?: string;
++  cardFrame: number;
++};
++
++export function parseCardListBalances(pageText: string): Map<string, ScrapedCardBalance> {
++  const balances = new Map<string, ScrapedCardBalance>();
++  const cardSections = pageText.split(AMEX_CARD_SECTION_SEPARATOR).slice(1);
++
++  cardSections.forEach(cardSection => {
++    const cardSuffix = cardSection.match(new RegExp(`^${CARD_SUFFIX_PATTERN}`))?.[1];
++    const balanceMatch = cardSection.match(AMEX_CARD_BALANCE_PATTERN);
++    if (!cardSuffix || !balanceMatch) {
++      return;
++    }
++
++    const balance = Number(balanceMatch[1].replace(/,/g, ''));
++    const cardFrame = Number(balanceMatch[2].replace(/,/g, ''));
++    const balanceDate = moment(balanceMatch[3].replace(/[.-]/g, '/'), DATE_FORMAT, true);
++    if (!Number.isFinite(balance) || !Number.isFinite(cardFrame) || !balanceDate.isValid()) {
++      return;
++    }
++
++    balances.set(cardSuffix, {
++      balance: -balance,
++      balanceDate: balanceDate.format(BALANCE_DATE_OUTPUT_FORMAT),
++      cardFrame,
++    });
++  });
++
++  const isracardBalanceDates = [...pageText.matchAll(new RegExp(ISRACARD_CARD_BALANCE_DATE_PATTERN, 'g'))].map(
++    ([, date]) => date,
++  );
++  const uniqueIsracardBalanceDates = [...new Set(isracardBalanceDates)];
++  const fallbackIsracardBalanceDate =
++    uniqueIsracardBalanceDates.length === 1 ? uniqueIsracardBalanceDates[0] : undefined;
++  const isracardCards = [...pageText.matchAll(ISRACARD_CARD_BALANCE_PATTERN)];
++
++  for (const isracardCard of isracardCards) {
++    const [, cardSuffix, cardFrameValue, remainingCreditValue] = isracardCard;
++    const cardBalanceDateValue = isracardCard[0].match(ISRACARD_CARD_BALANCE_DATE_PATTERN)?.[1];
++    const cardFrame = Number(cardFrameValue.replace(/,/g, ''));
++    const remainingCredit = Number(remainingCreditValue.replace(/,/g, ''));
++    // Cancelled cards have no usable frame and should not inherit another card's date.
++    const canUseFallbackBalanceDate = cardFrame > 0;
++    // Some active cards omit the date from their own block but share one page-level billing date.
++    const balanceDateValue =
++      cardBalanceDateValue ?? (canUseFallbackBalanceDate ? fallbackIsracardBalanceDate : undefined);
++    const balanceDate = balanceDateValue ? moment(balanceDateValue.replace(/[.-]/g, '/'), 'DD/MM', true) : undefined;
++    if (!Number.isFinite(cardFrame) || !Number.isFinite(remainingCredit) || (balanceDate && !balanceDate.isValid())) {
++      continue;
++    }
++
++    const balance = remainingCredit - cardFrame;
++    const formattedBalanceDate = balanceDate?.format(BALANCE_DATE_OUTPUT_FORMAT);
++    balances.set(cardSuffix, {
++      balance,
++      cardFrame,
++      ...(formattedBalanceDate ? { balanceDate: formattedBalanceDate } : {}),
++    });
++  }
++
++  return balances;
++}
++
+ function getAccountsUrl(servicesUrl: string, monthMoment: Moment) {
+   const billingDate = monthMoment.format('YYYY-MM-DD');
+   const url = new URL(servicesUrl);
+@@ -274,6 +354,26 @@ async function fetchTransactions(
+   return {};
+ }
+
++async function fetchCardBalances(page: Page, cardListPageUrl: string): Promise<Map<string, ScrapedCardBalance>> {
++  try {
++    debug(`opening card balance page ${cardListPageUrl}`);
++
++    await page.goto(cardListPageUrl, { waitUntil: 'domcontentloaded' });
++    debug(`card balance page loaded at ${page.url()}`);
++    await page.waitForFunction(
++      (markers: string[]) => markers.some(marker => document.body.innerText.includes(marker)),
++      {},
++      CARD_LIST_BALANCE_READY_MARKERS,
++    );
++    const balances = parseCardListBalances(await page.evaluate(() => document.body.innerText));
++    debug(`parsed card balances for ${balances.size} cards from card list page`);
++    return balances;
++  } catch (error) {
++    debug(`failed to fetch card balances from ${cardListPageUrl}`, error);
++    return new Map();
++  }
++}
++
+ async function getExtraScrapTransaction(
+   page: Page,
+   options: CompanyServiceOptions,
+@@ -368,6 +468,7 @@ async function fetchAllTransactions(
+     companyServiceOptions,
+     allMonths,
+   );
++  const cardBalances = await fetchCardBalances(page, companyServiceOptions.cardListPageUrl);
+   const combinedTxns: Record<string, Transaction[]> = {};
+
+   finalResult.forEach(result => {
+@@ -383,9 +484,16 @@ async function fetchAllTransactions(
+   });
+
+   const accounts = Object.keys(combinedTxns).map(accountNumber => {
++    const balance = cardBalances.get(accountNumber);
++    debug(
++      `account ${accountNumber} balance ${balance ? 'matched' : 'not matched'}${balance ? `: ${balance.balance}` : ''}`,
++    );
+     return {
+       accountNumber,
+       txns: combinedTxns[accountNumber],
++      balance: balance?.balance,
++      balanceDate: balance?.balanceDate,
++      cardFrame: balance?.cardFrame,
+     };
+   });
+
+@@ -405,12 +513,15 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
+
+   private servicesUrl: string;
+
++  private cardListPageUrl: string;
++
+   constructor(options: ScraperOptions, baseUrl: string, companyCode: string) {
+     super(options);
+
+     this.baseUrl = baseUrl;
+     this.companyCode = companyCode;
+     this.servicesUrl = `${baseUrl}/services/ProxyRequestHandler.ashx`;
++    this.cardListPageUrl = `${baseUrl}${CARD_LIST_PAGE_PATH}`;
+   }
+
+   async login(credentials: ScraperSpecificCredentials): Promise<ScraperScrapingResult> {
+@@ -516,6 +627,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
+       {
+         servicesUrl: this.servicesUrl,
+         companyCode: this.companyCode,
++        cardListPageUrl: this.cardListPageUrl,
+       },
+       startMoment,
+     );

--- a/.claude/skills/pr-safety-review/evals/fixtures/visa-cal-diff.txt
+++ b/.claude/skills/pr-safety-review/evals/fixtures/visa-cal-diff.txt
@@ -1,0 +1,56 @@
+diff --git a/src/scrapers/visa-cal.ts b/src/scrapers/visa-cal.ts
+index a240d9d74..dfe5e6b46 100644
+--- a/src/scrapers/visa-cal.ts
++++ b/src/scrapers/visa-cal.ts
+@@ -178,6 +178,7 @@ interface IssuedCardsGroup {
+   nextTotalDebitForAccount?: number;
+   nextTotalDebitDateForAccount?: string | null;
+   frameLimitForCardAmount?: number;
++  fictiveMaxAccAmt?: number;
+   cardLevelFrames?: CardLevelFrame[];
+ }
+
+@@ -531,17 +532,25 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
+     );
+
+     let frame: CardLevelFrame | undefined;
+-    let cardType: CardType;
++    let cardType: CardType = CardType.CompanyIssued;
+     let accountGroup: IssuedCardsGroup | undefined;
+
+     if (bankIssuedFrame) {
+       frame = bankIssuedFrame;
+       cardType = CardType.BankIssued;
+       accountGroup = frames.result?.bankIssuedCards;
+-    } else {
++    } else if (calIssuedFrame) {
+       frame = calIssuedFrame;
+       cardType = CardType.CompanyIssued;
+       accountGroup = frames.result?.calIssuedCards;
++    } else if (frames.result?.bankIssuedCards) {
++      // No card-level frame found, but account has bankIssuedCards data
++      cardType = CardType.BankIssued;
++      accountGroup = frames.result.bankIssuedCards;
++    } else if (frames.result?.calIssuedCards) {
++      // No card-level frame found, but account has calIssuedCards data
++      cardType = CardType.CompanyIssued;
++      accountGroup = frames.result.calIssuedCards;
+     }
+
+     debug('searching for frame for card %s, found: %O', card.cardUniqueId, frame);
+@@ -608,7 +617,14 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials>
+         : transactions;
+
+     // Use card-level balance if available, otherwise fall back to account-level balance
+-    const balanceAmount = frame?.nextTotalDebit ?? accountGroup?.nextTotalDebitForAccount;
++    // As a last resort, calculate balance from frame limit - fictive max account amount
++    const balanceAmount =
++      frame?.nextTotalDebit ??
++      accountGroup?.nextTotalDebitForAccount ??
++      (accountGroup?.frameLimitForCardAmount != null && accountGroup?.fictiveMaxAccAmt != null
++        ? accountGroup.frameLimitForCardAmount - accountGroup.fictiveMaxAccAmt
++        : undefined);
++
+     const result: TransactionsAccount = {
+       txns,
+       balance: balanceAmount != null ? -balanceAmount : undefined,


### PR DESCRIPTION
## Summary

Improves the `pr-safety-review` skill (used for fast PR safety verdicts on this repo) so it reads the surrounding conversation before handing back a verdict, and makes its eval suite reproducible.

This PR does **not** change any scraper behavior — all changes are under `.claude/skills/pr-safety-review/`.

## Changes

- **`SKILL.md`** — adds a "Conversation state" check that runs before the three code checks:
  - Filters out noise (bot housekeeping, author pings/apologies, non-actionable reactions) to find the most recent substantive ask from a maintainer/reviewer or review bot.
  - Compares that ask's timestamp to the most recent commit: if nothing has been pushed since, that's surfaced first, plainly, instead of handing back a routine verdict as if the PR just landed.
  - If commits do exist since the ask, checks whether they actually address it (not just that time passed) before treating the thread as resolved.
  - Applies the same reasoning per review-comment thread rather than trusting GitHub's `is_outdated`/`is_resolved` flags at face value.

- **`evals/evals.json` + two new fixture files** (`evals/fixtures/visa-cal-diff.txt`, `evals/fixtures/isracard-amex-diff.txt`) — the first two eval cases previously pointed at live PR URLs (#1153, #1154), so their outcome could drift if those PRs changed state between runs (this happened: #1154 merged mid-development). Converted both to static diff fixtures, matching eval case 3's existing pattern, so eval runs are reproducible.

https://claude.ai/code/session_01MSHLGJshCj2EJNqbtdEHdx