### PR TITLE
feat(leumi): add investment portfolio accounts

### DIFF
--- a/src/scrapers/leumi/leumi-investments.test.ts
+++ b/src/scrapers/leumi/leumi-investments.test.ts
@@ -1,0 +1,91 @@
+import { type ScraperOptions } from '../interface';
+import { parseHoldingsResponse, parseOrderHistoryResponse, parsePortfoliosResponse } from './leumi-investments';
+
+describe('parsePortfoliosResponse', () => {
+  test('extracts portfolios from the config response', () => {
+    const data = {
+      data: {
+        user: {
+          Portfolios: [{ PortfolioId: '12345', PortfolioName: 'תיק מסחר' }],
+        },
+      },
+    };
+
+    expect(parsePortfoliosResponse(data)).toEqual([{ PortfolioId: '12345', PortfolioName: 'תיק מסחר' }]);
+  });
+
+  test('returns an empty array when the response has no portfolios', () => {
+    expect(parsePortfoliosResponse({ data: { user: {} } })).toEqual([]);
+    expect(parsePortfoliosResponse({})).toEqual([]);
+    expect(parsePortfoliosResponse(null)).toEqual([]);
+  });
+});
+
+describe('parseHoldingsResponse', () => {
+  test('maps a holdings row to a Security', () => {
+    const data = {
+      data: {
+        UserStatement: {
+          DataSource: [{ PaperId: '662577', PaperName: 'טבע', Symbol: 'TEVA', Amount: '10', Value: '1234.5' }],
+        },
+      },
+    };
+
+    expect(parseHoldingsResponse(data)).toEqual([
+      { name: 'טבע', symbol: 'TEVA', volume: 10, value: 1234.5, currency: 'ILS' },
+    ]);
+  });
+
+  test('returns an empty array when there is no statement data', () => {
+    expect(parseHoldingsResponse({ data: {} })).toEqual([]);
+    expect(parseHoldingsResponse({})).toEqual([]);
+  });
+});
+
+describe('parseOrderHistoryResponse', () => {
+  const row = {
+    PaperId: '662577',
+    PaperName: 'טבע',
+    Symbol: 'TEVA',
+    Amount: '10',
+    ExecutableTotal: '1234.5',
+    ExecutablePrice: '123.45',
+    ExecutionDate: '18.06.26',
+  };
+
+  test('maps an order row to a transaction', () => {
+    const data = { data: { GetOrdersHistory: { ordersHistory: { records: [row] } } } };
+
+    const [transaction] = parseOrderHistoryResponse(data);
+
+    expect(transaction.originalAmount).toBe(1234.5);
+    expect(transaction.chargedAmount).toBe(1234.5);
+    expect(transaction.originalCurrency).toBe('ILS');
+    expect(transaction.description).toBe('טבע TEVA');
+  });
+
+  test('falls back to a generic description when paper name and symbol are missing', () => {
+    const data = {
+      data: { GetOrdersHistory: { ordersHistory: { records: [{ ...row, PaperName: '', Symbol: '' }] } } },
+    };
+
+    const [transaction] = parseOrderHistoryResponse(data);
+
+    expect(transaction.description).toBe('עסקה בתיק ניירות ערך');
+  });
+
+  test('returns an empty array when there is no order history', () => {
+    expect(parseOrderHistoryResponse({ data: {} })).toEqual([]);
+    expect(parseOrderHistoryResponse({})).toEqual([]);
+  });
+
+  test('includes the raw transaction only when requested', () => {
+    const data = { data: { GetOrdersHistory: { ordersHistory: { records: [row] } } } };
+
+    const withRaw = parseOrderHistoryResponse(data, { includeRawTransaction: true } as ScraperOptions);
+    const withoutRaw = parseOrderHistoryResponse(data, { includeRawTransaction: false } as ScraperOptions);
+
+    expect(withRaw[0].rawTransaction).toBeDefined();
+    expect(withoutRaw[0].rawTransaction).toBeUndefined();
+  });
+});

--- a/src/scrapers/leumi/leumi-investments.test.ts
+++ b/src/scrapers/leumi/leumi-investments.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { type ScraperOptions } from '../interface';
 import { parseHoldingsResponse, parseOrderHistoryResponse, parsePortfoliosResponse } from './leumi-investments';
 
@@ -43,47 +44,92 @@ describe('parseHoldingsResponse', () => {
 });
 
 describe('parseOrderHistoryResponse', () => {
-  const row = {
-    PaperId: '662577',
-    PaperName: 'טבע',
-    Symbol: 'TEVA',
-    Amount: '10',
-    ExecutableTotal: '1234.5',
-    ExecutablePrice: '123.45',
-    ExecutionDate: '18.06.26',
+  // Real rows observed on a live account's order history (a fund switch: sell one money-market
+  // fund, buy another). The response body is a plain array of rows, no wrapper object.
+  const sellRow = {
+    PaperName: 'ברק כספית',
+    Symbol: '',
+    TypeOfOperation: 2,
+    TypeOfOperationDesc: 'מכירה',
+    ExecutableTotal: -20023.91,
+    ExecutionDate: '2026-08-07 00:00',
+    DateOfFinancialVal: '2026-08-09 00:00',
+    TaxSum: -5.86,
+    BasicReferenceNo: 68096048524,
+    CurrencyACode: 'ILS',
+  };
+  const buyRow = {
+    PaperName: 'ברק כספית',
+    Symbol: '',
+    TypeOfOperation: 1,
+    TypeOfOperationDesc: 'קניה',
+    ExecutableTotal: 20000.48,
+    ExecutionDate: '2026-07-14 00:00',
+    DateOfFinancialVal: '2026-07-15 00:00',
+    TaxSum: 0,
+    BasicReferenceNo: 68096043916,
+    CurrencyACode: 'ILS',
   };
 
-  test('maps an order row to a transaction', () => {
-    const data = { data: { GetOrdersHistory: { ordersHistory: { records: [row] } } } };
+  test('maps a sell to a positive (credit) amount using its own sign, not the raw field sign', () => {
+    const [transaction] = parseOrderHistoryResponse([sellRow]);
 
-    const [transaction] = parseOrderHistoryResponse(data);
-
-    expect(transaction.originalAmount).toBe(1234.5);
-    expect(transaction.chargedAmount).toBe(1234.5);
+    // ExecutableTotal is itself negative for a sell (it tracks quantity direction), so the
+    // magnitude is what matters here - the sign comes from TypeOfOperation.
+    expect(transaction.originalAmount).toBe(20023.91);
+    expect(transaction.chargedAmount).toBe(20023.91);
     expect(transaction.originalCurrency).toBe('ILS');
-    expect(transaction.description).toBe('טבע TEVA');
+    expect(transaction.identifier).toBe(68096048524);
+  });
+
+  test('maps a buy to a negative (debit) amount', () => {
+    const [transaction] = parseOrderHistoryResponse([buyRow]);
+
+    expect(transaction.originalAmount).toBe(-20000.48);
+    expect(transaction.chargedAmount).toBe(-20000.48);
+  });
+
+  test('uses the execution date and the value date separately', () => {
+    const [transaction] = parseOrderHistoryResponse([sellRow]);
+
+    expect(transaction.date).toBe(moment('2026-08-07 00:00', 'YYYY-MM-DD HH:mm').milliseconds(0).toISOString());
+    expect(transaction.processedDate).toBe(
+      moment('2026-08-09 00:00', 'YYYY-MM-DD HH:mm').milliseconds(0).toISOString(),
+    );
+  });
+
+  test('describes the transaction using the paper name', () => {
+    const [transaction] = parseOrderHistoryResponse([sellRow]);
+
+    expect(transaction.description).toBe('ברק כספית');
   });
 
   test('falls back to a generic description when paper name and symbol are missing', () => {
-    const data = {
-      data: { GetOrdersHistory: { ordersHistory: { records: [{ ...row, PaperName: '', Symbol: '' }] } } },
-    };
-
-    const [transaction] = parseOrderHistoryResponse(data);
+    const [transaction] = parseOrderHistoryResponse([{ ...sellRow, PaperName: '', Symbol: '' }]);
 
     expect(transaction.description).toBe('עסקה בתיק ניירות ערך');
   });
 
-  test('returns an empty array when there is no order history', () => {
-    expect(parseOrderHistoryResponse({ data: {} })).toEqual([]);
+  test('notes a non-zero tax charge in the memo', () => {
+    const [transaction] = parseOrderHistoryResponse([sellRow]);
+
+    expect(transaction.memo).toBe('מס: 5.86 ₪');
+  });
+
+  test('omits the memo when there is no tax charge', () => {
+    const [transaction] = parseOrderHistoryResponse([buyRow]);
+
+    expect(transaction.memo).toBeUndefined();
+  });
+
+  test('returns an empty array when the response is not an array', () => {
     expect(parseOrderHistoryResponse({})).toEqual([]);
+    expect(parseOrderHistoryResponse(null)).toEqual([]);
   });
 
   test('includes the raw transaction only when requested', () => {
-    const data = { data: { GetOrdersHistory: { ordersHistory: { records: [row] } } } };
-
-    const withRaw = parseOrderHistoryResponse(data, { includeRawTransaction: true } as ScraperOptions);
-    const withoutRaw = parseOrderHistoryResponse(data, { includeRawTransaction: false } as ScraperOptions);
+    const withRaw = parseOrderHistoryResponse([sellRow], { includeRawTransaction: true } as ScraperOptions);
+    const withoutRaw = parseOrderHistoryResponse([sellRow], { includeRawTransaction: false } as ScraperOptions);
 
     expect(withRaw[0].rawTransaction).toBeDefined();
     expect(withoutRaw[0].rawTransaction).toBeUndefined();

--- a/src/scrapers/leumi/leumi-investments.test.ts
+++ b/src/scrapers/leumi/leumi-investments.test.ts
@@ -1,6 +1,11 @@
 import moment from 'moment';
 import { type ScraperOptions } from '../interface';
-import { parseHoldingsResponse, parseOrderHistoryResponse, parsePortfoliosResponse } from './leumi-investments';
+import {
+  parseHoldingsResponse,
+  parseOrderHistoryResponse,
+  parsePortfolioValue,
+  parsePortfoliosResponse,
+} from './leumi-investments';
 
 describe('parsePortfoliosResponse', () => {
   test('extracts portfolios from the config response', () => {
@@ -23,23 +28,36 @@ describe('parsePortfoliosResponse', () => {
 });
 
 describe('parseHoldingsResponse', () => {
+  // Real row observed on a live account holding a single money-market fund.
+  const holdingRow = { PaperId: 5141692, PaperName: 'ברק כספית', Symbol: '', Amount: 19526, Value: 20023.91 };
+
   test('maps a holdings row to a Security', () => {
-    const data = {
-      data: {
-        UserStatement: {
-          DataSource: [{ PaperId: '662577', PaperName: 'טבע', Symbol: 'TEVA', Amount: '10', Value: '1234.5' }],
-        },
-      },
-    };
+    const data = { data: { UserStatement: { DataSource: [holdingRow] } } };
 
     expect(parseHoldingsResponse(data)).toEqual([
-      { name: 'טבע', symbol: 'TEVA', volume: 10, value: 1234.5, currency: 'ILS' },
+      { name: 'ברק כספית', symbol: '', volume: 19526, value: 20023.91, currency: 'ILS' },
     ]);
   });
 
-  test('returns an empty array when there is no statement data', () => {
+  test('returns an empty array when the portfolio is empty (DataSource is null)', () => {
+    expect(parseHoldingsResponse({ data: { UserStatement: { DataSource: null } } })).toEqual([]);
     expect(parseHoldingsResponse({ data: {} })).toEqual([]);
     expect(parseHoldingsResponse({})).toEqual([]);
+  });
+});
+
+describe('parsePortfolioValue', () => {
+  test('reads the portfolio total from a non-empty statement', () => {
+    expect(parsePortfolioValue({ data: { UserStatement: { PortfolioValue: 20023.91 } } })).toBe(20023.91);
+  });
+
+  test('reads zero from an empty statement', () => {
+    expect(parsePortfolioValue({ data: { UserStatement: { PortfolioValue: 0 } } })).toBe(0);
+  });
+
+  test('returns undefined when there is no statement data', () => {
+    expect(parsePortfolioValue({ data: {} })).toBeUndefined();
+    expect(parsePortfolioValue({})).toBeUndefined();
   });
 });
 

--- a/src/scrapers/leumi/leumi-investments.test.ts
+++ b/src/scrapers/leumi/leumi-investments.test.ts
@@ -45,7 +45,9 @@ describe('parseHoldingsResponse', () => {
 
 describe('parseOrderHistoryResponse', () => {
   // Real rows observed on a live account's order history (a fund switch: sell one money-market
-  // fund, buy another). The response body is a plain array of rows, no wrapper object.
+  // fund, buy another). `wrap` reproduces the envelope a live GetOrdersHistory response uses.
+  const wrap = (records: unknown[]) => ({ data: { GetOrdersHistory: { ordersHistory: { records } } } });
+
   const sellRow = {
     PaperName: 'ברק כספית',
     Symbol: '',
@@ -72,7 +74,7 @@ describe('parseOrderHistoryResponse', () => {
   };
 
   test('maps a sell to a positive (credit) amount using its own sign, not the raw field sign', () => {
-    const [transaction] = parseOrderHistoryResponse([sellRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([sellRow]));
 
     // ExecutableTotal is itself negative for a sell (it tracks quantity direction), so the
     // magnitude is what matters here - the sign comes from TypeOfOperation.
@@ -83,14 +85,14 @@ describe('parseOrderHistoryResponse', () => {
   });
 
   test('maps a buy to a negative (debit) amount', () => {
-    const [transaction] = parseOrderHistoryResponse([buyRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([buyRow]));
 
     expect(transaction.originalAmount).toBe(-20000.48);
     expect(transaction.chargedAmount).toBe(-20000.48);
   });
 
   test('uses the execution date and the value date separately', () => {
-    const [transaction] = parseOrderHistoryResponse([sellRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([sellRow]));
 
     expect(transaction.date).toBe(moment('2026-08-07 00:00', 'YYYY-MM-DD HH:mm').milliseconds(0).toISOString());
     expect(transaction.processedDate).toBe(
@@ -99,37 +101,39 @@ describe('parseOrderHistoryResponse', () => {
   });
 
   test('describes the transaction using the paper name', () => {
-    const [transaction] = parseOrderHistoryResponse([sellRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([sellRow]));
 
     expect(transaction.description).toBe('ברק כספית');
   });
 
   test('falls back to a generic description when paper name and symbol are missing', () => {
-    const [transaction] = parseOrderHistoryResponse([{ ...sellRow, PaperName: '', Symbol: '' }]);
+    const [transaction] = parseOrderHistoryResponse(wrap([{ ...sellRow, PaperName: '', Symbol: '' }]));
 
     expect(transaction.description).toBe('עסקה בתיק ניירות ערך');
   });
 
   test('notes a non-zero tax charge in the memo', () => {
-    const [transaction] = parseOrderHistoryResponse([sellRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([sellRow]));
 
     expect(transaction.memo).toBe('מס: 5.86 ₪');
   });
 
   test('omits the memo when there is no tax charge', () => {
-    const [transaction] = parseOrderHistoryResponse([buyRow]);
+    const [transaction] = parseOrderHistoryResponse(wrap([buyRow]));
 
     expect(transaction.memo).toBeUndefined();
   });
 
-  test('returns an empty array when the response is not an array', () => {
+  test('returns an empty array when there is no order history', () => {
+    expect(parseOrderHistoryResponse(wrap([]))).toEqual([]);
+    expect(parseOrderHistoryResponse({ data: {} })).toEqual([]);
     expect(parseOrderHistoryResponse({})).toEqual([]);
     expect(parseOrderHistoryResponse(null)).toEqual([]);
   });
 
   test('includes the raw transaction only when requested', () => {
-    const withRaw = parseOrderHistoryResponse([sellRow], { includeRawTransaction: true } as ScraperOptions);
-    const withoutRaw = parseOrderHistoryResponse([sellRow], { includeRawTransaction: false } as ScraperOptions);
+    const withRaw = parseOrderHistoryResponse(wrap([sellRow]), { includeRawTransaction: true } as ScraperOptions);
+    const withoutRaw = parseOrderHistoryResponse(wrap([sellRow]), { includeRawTransaction: false } as ScraperOptions);
 
     expect(withRaw[0].rawTransaction).toBeDefined();
     expect(withoutRaw[0].rawTransaction).toBeUndefined();

--- a/src/scrapers/leumi/leumi-investments.ts
+++ b/src/scrapers/leumi/leumi-investments.ts
@@ -1,8 +1,8 @@
 import moment, { type Moment } from 'moment';
-import { type HTTPResponse, type Page } from 'puppeteer';
+import { type Page } from 'puppeteer';
 import { SHEKEL_CURRENCY } from '../../constants';
 import { getDebug } from '../../helpers/debug';
-import { waitUntilElementFound } from '../../helpers/elements-interactions';
+import { fetchGetWithinPage } from '../../helpers/fetch';
 import { getRawTransaction } from '../../helpers/transactions';
 import {
   TransactionStatuses,
@@ -15,10 +15,14 @@ import { type ScraperOptions } from '../interface';
 
 const debug = getDebug('leumi-investments');
 const BASE_URL = 'https://hb2.bankleumi.co.il';
-const TRADING_URL = `${BASE_URL}/lti/lti-app/trade/portfolio`;
-const TRADING_HISTORY_URL = `${BASE_URL}/lti/lti-app/trade/orders/history`;
+const CONFIG_URL = `${BASE_URL}/lti/lti-app/api/config`;
+const STATEMENT_URL = `${BASE_URL}/lti/lti-app/api/Trade/Statement`;
+const ORDERS_HISTORY_URL = `${BASE_URL}/lti/lti-app/api/Trade/GetOrdersHistory`;
 
-const PORTFOLIO_TABLE_SELECTOR = '.portfolio-tbl-sticky-native';
+const API_DATE_FORMAT = 'YYYY-MM-DD';
+const ORDER_DATE_FORMAT = 'YYYY-MM-DD HH:mm';
+const OPERATION_BUY = 1;
+const OPERATION_SELL = 2;
 
 interface RawPortfolio {
   PortfolioId: string;
@@ -54,14 +58,10 @@ interface RawOrder {
   CurrencyACode?: string;
 }
 
-const ORDER_DATE_FORMAT = 'YYYY-MM-DD HH:mm';
-const OPERATION_BUY = 1;
-const OPERATION_SELL = 2;
-
 /**
- * Extracted, unverified against a live response, from an earlier WIP branch. The response
- * shape is inferred from that code rather than freshly captured, so field names here should
- * be double-checked against a real `lti-app/api/config` payload before this ships.
+ * Verified against a live `lti-app/api/config` response. Portfolios are addressed by their
+ * position in this array elsewhere (see `buildStatementUrl`/`buildOrdersHistoryUrl`), which is
+ * how the live Statement/GetOrdersHistory requests identify a portfolio (`PortfolioIndex`).
  */
 export function parsePortfoliosResponse(data: any): RawPortfolio[] {
   return data?.data?.user?.Portfolios ?? [];
@@ -157,90 +157,77 @@ export function parseOrderHistoryResponse(data: any, options?: ScraperOptions): 
   });
 }
 
-async function fetchHoldings(
+/**
+ * Query params verified against a live request. `ViewID`/`SubView`/`FromCache`/
+ * `AlwaysChangePercent`/`IsMain`/`RegionId`/`CurrencyCode`/`rt` are reproduced verbatim from that
+ * request rather than understood - only `PortfolioIndex` and `ViewDate` vary per call here.
+ */
+function buildStatementUrl(portfolioIndex: number, asOfDate: string): string {
+  const params = new URLSearchParams({
+    PortfolioIndex: String(portfolioIndex),
+    StatementType: 'ByDate',
+    ViewDate: asOfDate,
+    ViewID: '7',
+    SubView: '16',
+    FromCache: 'false',
+    AlwaysChangePercent: 'false',
+    IsMain: 'false',
+    RegionId: '-1',
+    CurrencyCode: '0',
+    rt: 'true',
+  });
+  return `${STATEMENT_URL}?${params.toString()}`;
+}
+
+/** Query params verified against a live request. */
+function buildOrdersHistoryUrl(portfolioIndex: number, fromDate: string, toDate: string): string {
+  const params = new URLSearchParams({
+    portfolioIndex: String(portfolioIndex),
+    FromDate: fromDate,
+    Todate: toDate,
+    IsCryptoOnly: 'false',
+    rt: 'false',
+  });
+  return `${ORDERS_HISTORY_URL}?${params.toString()}`;
+}
+
+async function fetchPortfolioAccount(
   page: Page,
-): Promise<{ portfolioId: string; securities: Security[]; balance: number } | null> {
-  const configResponsePromise = waitForXhr(page, 'lti-app/api/config');
-  const statementResponsePromise = waitForXhr(page, 'Statement');
+  portfolioIndex: number,
+  portfolio: RawPortfolio,
+  startDate: Moment,
+  options: ScraperOptions,
+): Promise<TransactionsAccount | null> {
+  const today = moment().format(API_DATE_FORMAT);
 
-  await page.goto(TRADING_URL, { waitUntil: 'networkidle2' });
-  await waitUntilElementFound(page, PORTFOLIO_TABLE_SELECTOR, true);
+  const statementData = await fetchGetWithinPage<any>(page, buildStatementUrl(portfolioIndex, today));
+  const securities = parseHoldingsResponse(statementData);
+  const balance = parsePortfolioValue(statementData) ?? securities.reduce((sum, security) => sum + security.value, 0);
 
-  const [configResponse, statementResponse] = await Promise.all([configResponsePromise, statementResponsePromise]);
+  let txns: Transaction[] = [];
+  try {
+    const ordersUrl = buildOrdersHistoryUrl(portfolioIndex, startDate.format(API_DATE_FORMAT), today);
+    const ordersData = await fetchGetWithinPage<any>(page, ordersUrl);
+    txns = parseOrderHistoryResponse(ordersData, options);
+  } catch (error) {
+    debug('error fetching order history for portfolio %s: %s', portfolio.PortfolioId, error);
+  }
 
-  const portfolios = parsePortfoliosResponse(await configResponse.json());
-  if (!portfolios.length) {
-    debug('no portfolios found on the trading page');
+  if (balance === 0 && securities.length === 0 && txns.length === 0) {
+    debug('skipping empty portfolio %s', portfolio.PortfolioId);
     return null;
   }
-  if (portfolios.length > 1) {
-    // Only the currently-displayed portfolio's holdings are captured below; switching between
-    // portfolios in the UI to attribute holdings per-portfolio is not implemented yet.
-    debug('found %d portfolios, only %s is supported for now', portfolios.length, portfolios[0].PortfolioId);
-  }
 
-  const statementJson = await statementResponse.json();
-  const securities = parseHoldingsResponse(statementJson);
-  const balance = parsePortfolioValue(statementJson) ?? securities.reduce((sum, security) => sum + security.value, 0);
+  debug('found portfolio %s with %d securities and %d orders', portfolio.PortfolioId, securities.length, txns.length);
 
-  return { portfolioId: portfolios[0].PortfolioId, securities, balance };
-}
-
-function waitForXhr(page: Page, urlSubstring: string): Promise<HTTPResponse> {
-  return page.waitForResponse(
-    response =>
-      (response.request().resourceType() === 'xhr' || response.request().resourceType() === 'fetch') &&
-      response.url().includes(urlSubstring),
-  );
-}
-
-async function clickByXPath(page: Page, xpath: string): Promise<void> {
-  await page.waitForSelector(xpath, { timeout: 30000, visible: true });
-  const elements = await page.$$(xpath);
-  await elements[0].click();
-}
-
-/**
- * Drives the Angular Material date picker on the order-history page to select a custom start
- * date. Selectors carried over, unverified today, from an earlier WIP branch that exercised
- * this flow against a live account.
- */
-async function selectHistoryStartDate(page: Page, startDate: Moment): Promise<void> {
-  await page.waitForSelector('div.select-period-block');
-  await clickByXPath(page, 'xpath///div[contains(@class, "select-period-block")]');
-
-  await page.waitForSelector('div.mat-select-panel-wrap');
-  await clickByXPath(page, 'xpath///mat-option[last()]');
-
-  await page.waitForSelector('div#chooseByDatesBlock');
-  await clickByXPath(page, 'xpath///div[@id="chooseByDatesBlock"]//input[@id="mat-input-0"]');
-
-  await page.waitForSelector('mat-calendar');
-  await clickByXPath(page, 'xpath///mat-calendar//button[contains(@class, "mat-calendar-period-button")]');
-
-  const year = startDate.get('year');
-  await page.waitForSelector(`mat-calendar td[aria-label="${year}"]`);
-  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${year}")]`);
-
-  const month = `01/${startDate.format('MM/YY')}`;
-  await page.waitForSelector(`mat-calendar td[aria-label="${month}"]`);
-  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${month}")]`);
-
-  const day = startDate.format('DD/MM/YY');
-  await page.waitForSelector(`mat-calendar td[aria-label="${day}"]`);
-  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${day}")]`);
-}
-
-async function fetchOrderHistory(page: Page, startDate: Moment, options: ScraperOptions): Promise<Transaction[]> {
-  await page.goto(TRADING_HISTORY_URL, { waitUntil: 'networkidle2' });
-
-  await selectHistoryStartDate(page, startDate);
-
-  const responsePromise = waitForXhr(page, 'GetOrdersHistory');
-  await clickByXPath(page, 'xpath///div[@id="chooseByDatesBlock"]//button[contains(@class, "btn-primary")]');
-  const response = await responsePromise;
-
-  return parseOrderHistoryResponse(await response.json(), options);
+  return {
+    accountNumber: `${portfolio.PortfolioId}-investment`,
+    balance,
+    currency: SHEKEL_CURRENCY,
+    savingsAccount: true,
+    securities,
+    txns,
+  };
 }
 
 export async function fetchInvestmentAccounts(
@@ -251,34 +238,27 @@ export async function fetchInvestmentAccounts(
   debug('========== FETCHING INVESTMENT ACCOUNTS ==========');
 
   try {
-    const portfolio = await fetchHoldings(page);
-    if (!portfolio) {
+    const configData = await fetchGetWithinPage<any>(page, CONFIG_URL);
+    const portfolios = parsePortfoliosResponse(configData);
+    if (!portfolios.length) {
+      debug('no portfolios found');
       return [];
     }
 
-    let txns: Transaction[] = [];
-    try {
-      txns = await fetchOrderHistory(page, startDate, options);
-    } catch (error) {
-      debug('error fetching order history, returning holdings without transactions: %s', error);
+    const accounts: TransactionsAccount[] = [];
+    for (let index = 0; index < portfolios.length; index += 1) {
+      try {
+        const account = await fetchPortfolioAccount(page, index, portfolios[index], startDate, options);
+        if (account) {
+          accounts.push(account);
+        }
+      } catch (error) {
+        debug('error fetching portfolio %s: %s', portfolios[index].PortfolioId, error);
+      }
     }
 
-    const account: TransactionsAccount = {
-      accountNumber: `${portfolio.portfolioId}-investment`,
-      balance: portfolio.balance,
-      currency: SHEKEL_CURRENCY,
-      savingsAccount: true,
-      securities: portfolio.securities,
-      txns,
-    };
-
-    debug(
-      'found portfolio %s with %d securities and %d orders',
-      portfolio.portfolioId,
-      portfolio.securities.length,
-      txns.length,
-    );
-    return [account];
+    debug('returning %d investment accounts', accounts.length);
+    return accounts;
   } catch (error) {
     debug('error fetching investment accounts: %s', error);
     return [];

--- a/src/scrapers/leumi/leumi-investments.ts
+++ b/src/scrapers/leumi/leumi-investments.ts
@@ -34,8 +34,8 @@ interface RawHolding {
 }
 
 /**
- * One row of a live `GetOrdersHistory` response - the response body itself is a plain array
- * of these, with no wrapper object.
+ * One row of `data.GetOrdersHistory.ordersHistory.records` in a live `GetOrdersHistory`
+ * response - the old WIP branch's guess at this wrapper path was actually correct.
  */
 interface RawOrder {
   BasicReferenceNo: number;
@@ -95,7 +95,7 @@ export function parseHoldingsResponse(data: any): Security[] {
  * sell a positive (money coming in).
  */
 export function parseOrderHistoryResponse(data: any, options?: ScraperOptions): Transaction[] {
-  const rows: RawOrder[] = Array.isArray(data) ? data : [];
+  const rows: RawOrder[] = data?.data?.GetOrdersHistory?.ordersHistory?.records ?? [];
 
   return rows.map(row => {
     const date = moment(row.ExecutionDate, ORDER_DATE_FORMAT).milliseconds(0).toISOString();

--- a/src/scrapers/leumi/leumi-investments.ts
+++ b/src/scrapers/leumi/leumi-investments.ts
@@ -1,0 +1,230 @@
+import moment, { type Moment } from 'moment';
+import { type HTTPResponse, type Page } from 'puppeteer';
+import { SHEKEL_CURRENCY } from '../../constants';
+import { getDebug } from '../../helpers/debug';
+import { waitUntilElementFound } from '../../helpers/elements-interactions';
+import { getRawTransaction } from '../../helpers/transactions';
+import {
+  TransactionStatuses,
+  TransactionTypes,
+  type Security,
+  type Transaction,
+  type TransactionsAccount,
+} from '../../transactions';
+import { type ScraperOptions } from '../interface';
+
+const debug = getDebug('leumi-investments');
+const BASE_URL = 'https://hb2.bankleumi.co.il';
+const TRADING_URL = `${BASE_URL}/lti/lti-app/trade/portfolio`;
+const TRADING_HISTORY_URL = `${BASE_URL}/lti/lti-app/trade/orders/history`;
+
+const PORTFOLIO_TABLE_SELECTOR = '.portfolio-tbl-sticky-native';
+const DATE_FORMAT = 'DD.MM.YY';
+
+interface RawPortfolio {
+  PortfolioId: string;
+  PortfolioName: string;
+}
+
+interface RawHolding {
+  PaperId: string;
+  PaperName?: string;
+  Symbol?: string;
+  Amount: string;
+  Value: string;
+}
+
+interface RawOrder {
+  PaperId: string;
+  PaperName?: string;
+  Symbol?: string;
+  Amount: string;
+  ExecutableTotal: string;
+  ExecutablePrice: string;
+  ExecutionDate: string;
+}
+
+/**
+ * Extracted, unverified against a live response, from an earlier WIP branch. The response
+ * shape is inferred from that code rather than freshly captured, so field names here should
+ * be double-checked against a real `lti-app/api/config` payload before this ships.
+ */
+export function parsePortfoliosResponse(data: any): RawPortfolio[] {
+  return data?.data?.user?.Portfolios ?? [];
+}
+
+/**
+ * Same provenance note as {@link parsePortfoliosResponse}: field names are carried over from
+ * an earlier WIP branch, not freshly observed. The earlier branch also always reported ILS
+ * regardless of the source `CurrencyRate` field, which is assumed here to mean Leumi's trading
+ * platform prices holdings in ILS - that assumption needs confirming against a live account.
+ */
+export function parseHoldingsResponse(data: any): Security[] {
+  const rows: RawHolding[] = data?.data?.UserStatement?.DataSource ?? [];
+
+  return rows.map(row => ({
+    name: row.PaperName || undefined,
+    symbol: row.Symbol || '',
+    volume: parseFloat(row.Amount),
+    value: parseFloat(row.Value),
+    currency: SHEKEL_CURRENCY,
+  }));
+}
+
+/**
+ * Same provenance note as {@link parsePortfoliosResponse}. Additionally, the earlier branch
+ * never captured a buy/sell direction field for orders, so `chargedAmount` here is the
+ * unsigned trade value rather than a signed debit/credit - that needs a real order-history
+ * response to fix properly.
+ */
+export function parseOrderHistoryResponse(data: any, options?: ScraperOptions): Transaction[] {
+  const rows: RawOrder[] = data?.data?.GetOrdersHistory?.ordersHistory?.records ?? [];
+
+  return rows.map(row => {
+    const date = moment(row.ExecutionDate, DATE_FORMAT).milliseconds(0).toISOString();
+    const amount = parseFloat(row.ExecutableTotal);
+    const paperLabel = [row.PaperName, row.Symbol].filter(Boolean).join(' ');
+
+    const transaction: Transaction = {
+      type: TransactionTypes.Normal,
+      date,
+      processedDate: date,
+      originalAmount: amount,
+      originalCurrency: SHEKEL_CURRENCY,
+      chargedAmount: amount,
+      description: paperLabel || 'עסקה בתיק ניירות ערך',
+      status: TransactionStatuses.Completed,
+    };
+
+    if (options?.includeRawTransaction) {
+      transaction.rawTransaction = getRawTransaction(row);
+    }
+
+    return transaction;
+  });
+}
+
+async function fetchHoldings(page: Page): Promise<{ portfolioId: string; securities: Security[] } | null> {
+  const configResponsePromise = waitForXhr(page, 'lti-app/api/config');
+  const statementResponsePromise = waitForXhr(page, 'Statement');
+
+  await page.goto(TRADING_URL, { waitUntil: 'networkidle2' });
+  await waitUntilElementFound(page, PORTFOLIO_TABLE_SELECTOR, true);
+
+  const [configResponse, statementResponse] = await Promise.all([configResponsePromise, statementResponsePromise]);
+
+  const portfolios = parsePortfoliosResponse(await configResponse.json());
+  if (!portfolios.length) {
+    debug('no portfolios found on the trading page');
+    return null;
+  }
+  if (portfolios.length > 1) {
+    // Only the currently-displayed portfolio's holdings are captured below; switching between
+    // portfolios in the UI to attribute holdings per-portfolio is not implemented yet.
+    debug('found %d portfolios, only %s is supported for now', portfolios.length, portfolios[0].PortfolioId);
+  }
+
+  const securities = parseHoldingsResponse(await statementResponse.json());
+  return { portfolioId: portfolios[0].PortfolioId, securities };
+}
+
+function waitForXhr(page: Page, urlSubstring: string): Promise<HTTPResponse> {
+  return page.waitForResponse(
+    response =>
+      (response.request().resourceType() === 'xhr' || response.request().resourceType() === 'fetch') &&
+      response.url().includes(urlSubstring),
+  );
+}
+
+async function clickByXPath(page: Page, xpath: string): Promise<void> {
+  await page.waitForSelector(xpath, { timeout: 30000, visible: true });
+  const elements = await page.$$(xpath);
+  await elements[0].click();
+}
+
+/**
+ * Drives the Angular Material date picker on the order-history page to select a custom start
+ * date. Selectors carried over, unverified today, from an earlier WIP branch that exercised
+ * this flow against a live account.
+ */
+async function selectHistoryStartDate(page: Page, startDate: Moment): Promise<void> {
+  await page.waitForSelector('div.select-period-block');
+  await clickByXPath(page, 'xpath///div[contains(@class, "select-period-block")]');
+
+  await page.waitForSelector('div.mat-select-panel-wrap');
+  await clickByXPath(page, 'xpath///mat-option[last()]');
+
+  await page.waitForSelector('div#chooseByDatesBlock');
+  await clickByXPath(page, 'xpath///div[@id="chooseByDatesBlock"]//input[@id="mat-input-0"]');
+
+  await page.waitForSelector('mat-calendar');
+  await clickByXPath(page, 'xpath///mat-calendar//button[contains(@class, "mat-calendar-period-button")]');
+
+  const year = startDate.get('year');
+  await page.waitForSelector(`mat-calendar td[aria-label="${year}"]`);
+  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${year}")]`);
+
+  const month = `01/${startDate.format('MM/YY')}`;
+  await page.waitForSelector(`mat-calendar td[aria-label="${month}"]`);
+  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${month}")]`);
+
+  const day = startDate.format('DD/MM/YY');
+  await page.waitForSelector(`mat-calendar td[aria-label="${day}"]`);
+  await clickByXPath(page, `xpath///mat-calendar//td[contains(@aria-label, "${day}")]`);
+}
+
+async function fetchOrderHistory(page: Page, startDate: Moment, options: ScraperOptions): Promise<Transaction[]> {
+  await page.goto(TRADING_HISTORY_URL, { waitUntil: 'networkidle2' });
+
+  await selectHistoryStartDate(page, startDate);
+
+  const responsePromise = waitForXhr(page, 'GetOrdersHistory');
+  await clickByXPath(page, 'xpath///div[@id="chooseByDatesBlock"]//button[contains(@class, "btn-primary")]');
+  const response = await responsePromise;
+
+  return parseOrderHistoryResponse(await response.json(), options);
+}
+
+export async function fetchInvestmentAccounts(
+  page: Page,
+  startDate: Moment,
+  options: ScraperOptions,
+): Promise<TransactionsAccount[]> {
+  debug('========== FETCHING INVESTMENT ACCOUNTS ==========');
+
+  try {
+    const portfolio = await fetchHoldings(page);
+    if (!portfolio) {
+      return [];
+    }
+
+    let txns: Transaction[] = [];
+    try {
+      txns = await fetchOrderHistory(page, startDate, options);
+    } catch (error) {
+      debug('error fetching order history, returning holdings without transactions: %s', error);
+    }
+
+    const balance = portfolio.securities.reduce((sum, security) => sum + security.value, 0);
+
+    const account: TransactionsAccount = {
+      accountNumber: `${portfolio.portfolioId}-investment`,
+      balance,
+      currency: SHEKEL_CURRENCY,
+      savingsAccount: true,
+      securities: portfolio.securities,
+      txns,
+    };
+
+    debug(
+      'found portfolio %s with %d securities and %d orders',
+      portfolio.portfolioId,
+      portfolio.securities.length,
+      txns.length,
+    );
+    return [account];
+  } catch (error) {
+    debug('error fetching investment accounts: %s', error);
+    return [];
+  }
+}

--- a/src/scrapers/leumi/leumi-investments.ts
+++ b/src/scrapers/leumi/leumi-investments.ts
@@ -19,7 +19,6 @@ const TRADING_URL = `${BASE_URL}/lti/lti-app/trade/portfolio`;
 const TRADING_HISTORY_URL = `${BASE_URL}/lti/lti-app/trade/orders/history`;
 
 const PORTFOLIO_TABLE_SELECTOR = '.portfolio-tbl-sticky-native';
-const DATE_FORMAT = 'DD.MM.YY';
 
 interface RawPortfolio {
   PortfolioId: string;
@@ -34,15 +33,31 @@ interface RawHolding {
   Value: string;
 }
 
+/**
+ * One row of a live `GetOrdersHistory` response - the response body itself is a plain array
+ * of these, with no wrapper object.
+ */
 interface RawOrder {
-  PaperId: string;
+  BasicReferenceNo: number;
   PaperName?: string;
   Symbol?: string;
-  Amount: string;
-  ExecutableTotal: string;
-  ExecutablePrice: string;
+  /** 1 = buy (קניה), 2 = sell (מכירה); other values are unmapped. */
+  TypeOfOperation: number;
+  TypeOfOperationDesc?: string;
+  /**
+   * Signed by quantity direction (positive on a buy, negative on a sell) rather than by cash
+   * flow, so it is not used directly - see {@link parseOrderHistoryResponse}.
+   */
+  ExecutableTotal: number;
   ExecutionDate: string;
+  DateOfFinancialVal?: string;
+  TaxSum?: number;
+  CurrencyACode?: string;
 }
+
+const ORDER_DATE_FORMAT = 'YYYY-MM-DD HH:mm';
+const OPERATION_BUY = 1;
+const OPERATION_SELL = 2;
 
 /**
  * Extracted, unverified against a live response, from an earlier WIP branch. The response
@@ -54,10 +69,11 @@ export function parsePortfoliosResponse(data: any): RawPortfolio[] {
 }
 
 /**
- * Same provenance note as {@link parsePortfoliosResponse}: field names are carried over from
- * an earlier WIP branch, not freshly observed. The earlier branch also always reported ILS
- * regardless of the source `CurrencyRate` field, which is assumed here to mean Leumi's trading
- * platform prices holdings in ILS - that assumption needs confirming against a live account.
+ * Field names are carried over from an earlier WIP branch, not freshly observed, and still need
+ * confirming against a real `Statement` response before this ships. Holdings are hardcoded to
+ * ILS, which matches a live account's holdings and the live `GetOrdersHistory` order rows (both
+ * confirmed via {@link parseOrderHistoryResponse}'s `CurrencyACode`), but is not itself read
+ * from a field here since the corresponding holdings field name hasn't been observed yet.
  */
 export function parseHoldingsResponse(data: any): Security[] {
   const rows: RawHolding[] = data?.data?.UserStatement?.DataSource ?? [];
@@ -72,29 +88,56 @@ export function parseHoldingsResponse(data: any): Security[] {
 }
 
 /**
- * Same provenance note as {@link parsePortfoliosResponse}. Additionally, the earlier branch
- * never captured a buy/sell direction field for orders, so `chargedAmount` here is the
- * unsigned trade value rather than a signed debit/credit - that needs a real order-history
- * response to fix properly.
+ * Verified against a live `GetOrdersHistory` response. `chargedAmount`/`originalAmount` are
+ * derived from `TypeOfOperation` rather than `ExecutableTotal`'s own sign, because that sign
+ * tracks quantity direction (positive on a buy, negative on a sell) - the opposite of a
+ * debit/credit convention, where a buy should be a negative (money leaving the account) and a
+ * sell a positive (money coming in).
  */
 export function parseOrderHistoryResponse(data: any, options?: ScraperOptions): Transaction[] {
-  const rows: RawOrder[] = data?.data?.GetOrdersHistory?.ordersHistory?.records ?? [];
+  const rows: RawOrder[] = Array.isArray(data) ? data : [];
 
   return rows.map(row => {
-    const date = moment(row.ExecutionDate, DATE_FORMAT).milliseconds(0).toISOString();
-    const amount = parseFloat(row.ExecutableTotal);
+    const date = moment(row.ExecutionDate, ORDER_DATE_FORMAT).milliseconds(0).toISOString();
+    const processedDate = row.DateOfFinancialVal
+      ? moment(row.DateOfFinancialVal, ORDER_DATE_FORMAT).milliseconds(0).toISOString()
+      : date;
+
+    const magnitude = Math.abs(row.ExecutableTotal);
+    let amount: number;
+    if (row.TypeOfOperation === OPERATION_BUY) {
+      amount = -magnitude;
+    } else if (row.TypeOfOperation === OPERATION_SELL) {
+      amount = magnitude;
+    } else {
+      debug(
+        'unrecognised operation type %s (%s) for order %s, using the raw signed amount',
+        row.TypeOfOperation,
+        row.TypeOfOperationDesc,
+        row.BasicReferenceNo,
+      );
+      amount = row.ExecutableTotal;
+    }
+
+    const currency = row.CurrencyACode || SHEKEL_CURRENCY;
     const paperLabel = [row.PaperName, row.Symbol].filter(Boolean).join(' ');
 
     const transaction: Transaction = {
       type: TransactionTypes.Normal,
+      identifier: row.BasicReferenceNo,
       date,
-      processedDate: date,
+      processedDate,
       originalAmount: amount,
-      originalCurrency: SHEKEL_CURRENCY,
+      originalCurrency: currency,
       chargedAmount: amount,
+      chargedCurrency: currency,
       description: paperLabel || 'עסקה בתיק ניירות ערך',
       status: TransactionStatuses.Completed,
     };
+
+    if (row.TaxSum) {
+      transaction.memo = `מס: ${Math.abs(row.TaxSum).toFixed(2)} ₪`;
+    }
 
     if (options?.includeRawTransaction) {
       transaction.rawTransaction = getRawTransaction(row);

--- a/src/scrapers/leumi/leumi-investments.ts
+++ b/src/scrapers/leumi/leumi-investments.ts
@@ -26,11 +26,10 @@ interface RawPortfolio {
 }
 
 interface RawHolding {
-  PaperId: string;
   PaperName?: string;
   Symbol?: string;
-  Amount: string;
-  Value: string;
+  Amount: number;
+  Value: number;
 }
 
 /**
@@ -69,11 +68,12 @@ export function parsePortfoliosResponse(data: any): RawPortfolio[] {
 }
 
 /**
- * Field names are carried over from an earlier WIP branch, not freshly observed, and still need
- * confirming against a real `Statement` response before this ships. Holdings are hardcoded to
- * ILS, which matches a live account's holdings and the live `GetOrdersHistory` order rows (both
- * confirmed via {@link parseOrderHistoryResponse}'s `CurrencyACode`), but is not itself read
- * from a field here since the corresponding holdings field name hasn't been observed yet.
+ * Verified against live responses, both empty (`DataSource: null`) and holding one fund
+ * (`DataSource: [{ PaperName: 'ברק כספית', Symbol: '', Amount: 19526, Value: 20023.91, ... }]`).
+ * `Amount`/`Value` are native numbers, unlike the string fields the old WIP branch's guess
+ * assumed. Currency is hardcoded to ILS, confirmed against a live account (and against the live
+ * `GetOrdersHistory` order rows' `CurrencyACode` in {@link parseOrderHistoryResponse}) - there is
+ * no per-holding currency field to read instead, since the observed holding is itself ILS-priced.
  */
 export function parseHoldingsResponse(data: any): Security[] {
   const rows: RawHolding[] = data?.data?.UserStatement?.DataSource ?? [];
@@ -81,10 +81,20 @@ export function parseHoldingsResponse(data: any): Security[] {
   return rows.map(row => ({
     name: row.PaperName || undefined,
     symbol: row.Symbol || '',
-    volume: parseFloat(row.Amount),
-    value: parseFloat(row.Value),
+    volume: row.Amount,
+    value: row.Value,
     currency: SHEKEL_CURRENCY,
   }));
+}
+
+/**
+ * `data.UserStatement.PortfolioValue` - verified against live responses (0 on an empty
+ * portfolio, and exactly matching the single holding's `Value` on a non-empty one) - is the
+ * account's own total, and is preferred over summing individual holdings' values since it also
+ * covers any uninvested cash sitting in the portfolio.
+ */
+export function parsePortfolioValue(data: any): number | undefined {
+  return data?.data?.UserStatement?.PortfolioValue;
 }
 
 /**
@@ -147,7 +157,9 @@ export function parseOrderHistoryResponse(data: any, options?: ScraperOptions): 
   });
 }
 
-async function fetchHoldings(page: Page): Promise<{ portfolioId: string; securities: Security[] } | null> {
+async function fetchHoldings(
+  page: Page,
+): Promise<{ portfolioId: string; securities: Security[]; balance: number } | null> {
   const configResponsePromise = waitForXhr(page, 'lti-app/api/config');
   const statementResponsePromise = waitForXhr(page, 'Statement');
 
@@ -167,8 +179,11 @@ async function fetchHoldings(page: Page): Promise<{ portfolioId: string; securit
     debug('found %d portfolios, only %s is supported for now', portfolios.length, portfolios[0].PortfolioId);
   }
 
-  const securities = parseHoldingsResponse(await statementResponse.json());
-  return { portfolioId: portfolios[0].PortfolioId, securities };
+  const statementJson = await statementResponse.json();
+  const securities = parseHoldingsResponse(statementJson);
+  const balance = parsePortfolioValue(statementJson) ?? securities.reduce((sum, security) => sum + security.value, 0);
+
+  return { portfolioId: portfolios[0].PortfolioId, securities, balance };
 }
 
 function waitForXhr(page: Page, urlSubstring: string): Promise<HTTPResponse> {
@@ -248,11 +263,9 @@ export async function fetchInvestmentAccounts(
       debug('error fetching order history, returning holdings without transactions: %s', error);
     }
 
-    const balance = portfolio.securities.reduce((sum, security) => sum + security.value, 0);
-
     const account: TransactionsAccount = {
       accountNumber: `${portfolio.portfolioId}-investment`,
-      balance,
+      balance: portfolio.balance,
       currency: SHEKEL_CURRENCY,
       savingsAccount: true,
       securities: portfolio.securities,

--- a/src/scrapers/leumi/leumi.test.ts
+++ b/src/scrapers/leumi/leumi.test.ts
@@ -107,5 +107,41 @@ describe('Leumi legacy scraper', () => {
     } else {
       debug('No foreign currency accounts found - this may be expected if the test account has none');
     }
+
+    // Validate investment accounts if they exist
+    const investmentAccounts = result.accounts?.filter(account => account.accountNumber.endsWith('-investment'));
+
+    debug('Investment accounts found:', investmentAccounts?.length);
+
+    if (investmentAccounts && investmentAccounts.length > 0) {
+      debug('Investment account details:');
+      investmentAccounts.forEach(account => {
+        debug(
+          `  - Account: ${account.accountNumber}, Balance: ${account.balance}, Securities: ${account.securities?.length}, Transactions: ${account.txns.length}`,
+        );
+        account.securities?.forEach(security => {
+          debug(
+            `      - ${security.name} (${security.symbol}): ${security.volume} @ ${security.value} ${security.currency}`,
+          );
+        });
+        account.txns.forEach(txn => {
+          debug(`      - ${txn.date}: ${txn.description} ${txn.chargedAmount} ${txn.chargedCurrency}`);
+        });
+      });
+
+      investmentAccounts.forEach(account => {
+        expect(account.savingsAccount).toBe(true);
+        expect(account.balance).toBeDefined();
+        expect(account.securities).toBeDefined();
+        expect(account.txns).toBeDefined();
+
+        account.txns.forEach(txn => {
+          expect(Number.isNaN(txn.originalAmount)).toBe(false);
+          expect(txn.date).toBeDefined();
+        });
+      });
+    } else {
+      debug('No investment accounts found - this may be expected if the test account has none');
+    }
   });
 });

--- a/src/scrapers/leumi/leumi.ts
+++ b/src/scrapers/leumi/leumi.ts
@@ -10,6 +10,7 @@ import { TransactionStatuses, TransactionTypes, type Transaction, type Transacti
 import { BaseScraperWithBrowser, LoginResults, type LoginOptions } from '../base-scraper-with-browser';
 import { type ScraperOptions, type ScraperScrapingResult } from '../interface';
 import { fetchForeignCurrencyAccounts } from './leumi-forex';
+import { fetchInvestmentAccounts } from './leumi-investments';
 
 const debug = getDebug('leumi');
 const BASE_URL = 'https://hb2.bankleumi.co.il';
@@ -361,6 +362,9 @@ class LeumiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
 
     const foreignCurrencyAccounts = await fetchForeignCurrencyAccounts(this.page, startMoment, this.options);
     accounts.push(...foreignCurrencyAccounts);
+
+    const investmentAccounts = await fetchInvestmentAccounts(this.page, startMoment, this.options);
+    accounts.push(...investmentAccounts);
 
     return {
       success: true,

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -7,6 +7,7 @@ export interface TransactionsAccount {
   currency?: string;
   savingsAccount?: boolean;
   txns: Transaction[];
+  securities?: Security[];
 }
 
 export enum CardType {
@@ -60,4 +61,17 @@ export interface Transaction {
   installments?: TransactionInstallments;
   category?: string;
   rawTransaction?: unknown;
+}
+
+/**
+ * A single security holding within an investment account.
+ */
+export interface Security {
+  name?: string;
+  symbol: string;
+  volume: number;
+  value: number;
+  currency?: string;
+  changePercentage?: number;
+  profitLoss?: number;
 }


### PR DESCRIPTION
Adds Leumi trading-portfolio holdings and order history as investment accounts, following #1149 into the trading side of the account: same "no new top-level shape" approach, appending to the existing `accounts` array.

### Schema

Aligned with #1026's convention rather than my own earlier, closed #972 (bespoke `Portfolio`/`Investment`/`InvestmentTransaction` types + a new top-level `portfolios` field, which never got real review): an investment portfolio is a regular `TransactionsAccount` entry (`accountNumber` suffixed `-investment`, `savingsAccount: true`) with a new `securities: Security[]` field, matching the `Security` interface #1026 already introduced (`name?`, `symbol`, `volume`, `value`, `currency?`, `changePercentage?`, `profitLoss?`).

### Implementation

New `src/scrapers/leumi/leumi-investments.ts`. Rather than driving the trading page's UI (an Angular Material date picker, in particular), it calls the same three endpoints the page itself calls, directly:

* `GET /lti/lti-app/api/config` - lists portfolios
* `GET /lti/lti-app/api/Trade/Statement?PortfolioIndex=...` - current holdings + `PortfolioValue` (used as the account balance, since it also covers uninvested cash, rather than summing holdings)
* `GET /lti/lti-app/api/Trade/GetOrdersHistory?portfolioIndex=...&FromDate=...&Todate=...` - order history, mapped to `Transaction[]`

All three are plain authenticated GETs (same pattern as the existing savings-account fetch, via `fetchGetWithinPage`), so no browser interaction beyond being logged in is needed. Portfolios are addressed by their index in the `config` response, so multiple portfolios are all fetched (unlike an earlier draft of this that only handled the first one).

One thing worth calling out: order rows carry `ExecutableTotal` signed by *quantity* direction (positive on a buy, negative on a sell) rather than cash-flow direction, so the transaction amount is instead derived from the `TypeOfOperation` field (1 = buy, 2 = sell) - a buy is a negative amount (money leaving the account), a sell positive.

### Testing

`npm run lint`, `tsc --noEmit` and the full jest suite pass. Unit tests cover the pure parsing functions against real (redacted account numbers) response shapes captured from a live account: an empty portfolio, one holding a single money-market fund, and an order-history pair (a fund switch: sell one fund, buy another).

Verified end to end against a live Leumi account via the existing `leumi.test.ts` live-API test (extended here to validate investment accounts the same way it already validates savings/forex accounts).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1W6K5gQtDmeQqLUfJQxEq