### PR TITLE
fix(mizrahi): parse balance, isolate account failures, add foreign currency accounts

### DIFF
--- a/src/scrapers/mizrahi.test.ts
+++ b/src/scrapers/mizrahi.test.ts
@@ -1,4 +1,10 @@
-import MizrahiScraper, { parseAmount, scrapeAccounts, convertPendingRow } from './mizrahi';
+import moment from 'moment';
+import MizrahiScraper, {
+  parseAmount,
+  scrapeAccounts,
+  convertPendingRow,
+  convertForeignCurrencyAccounts,
+} from './mizrahi';
 import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
 import { SCRAPERS } from '../definitions';
 import { ISO_DATE_REGEX } from '../constants';
@@ -212,7 +218,7 @@ describe('scrapeAccounts', () => {
       if (index === 1) {
         return Promise.reject(new Error('boom'));
       }
-      return Promise.resolve(makeAccount(`acc-${index}`));
+      return Promise.resolve([makeAccount(`acc-${index}`)]);
     });
 
     const { accounts, errors } = await scrapeAccounts(3, selectAccount, fetchAccount);
@@ -274,4 +280,238 @@ describe('scrapeAccounts', () => {
     expect(errors[0]).toBe(`account #1: ${String(aggregate)}`);
     expect(errors[0]).not.toMatch(/account #1: $/);
   });
+});
+
+describe('convertForeignCurrencyAccounts', () => {
+  const placeholderTransaction = {
+    TRANSACTION_DATE: '',
+    ERECH_DATE: '',
+    SUG_ISKA_CODE: '',
+    SUG_ISKA_DESC: '',
+    TNUA_AMT: '',
+    ASMACHTA: '',
+    ITRA_CURRENT_AMT: '',
+    MATBEA_CODE: '',
+    TNUA_NUM: '',
+    KABAH_CODE: '',
+    KABAH_NAME: '',
+  };
+
+  function makeResponse(rows: Record<string, unknown>) {
+    return {
+      header: { success: null, messages: [] },
+      body: {
+        table: {
+          rows: {
+            RET_MESSAGE: 'תקין',
+            RET_CODE: '1',
+            FCR_AGG_DATA_ARR: [],
+            FCR_TRANS_DATA_ARR: [placeholderTransaction],
+            FCR_PENDING_TRANS_ARR: [placeholderTransaction],
+            ...rows,
+          },
+        },
+      },
+    };
+  }
+
+  test('maps the exact sample response from the discovery note', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [
+        {
+          ITRAT_FCR_BOOKED: '104.96',
+          ITRAT_FCR_PENDING: '104.96',
+          MATBEA_CODE: '1',
+          MATBEA_NAME: 'דולר ארה"ב',
+          MATBEA_SHORT_NAME: 'דולר',
+          MATBEA_SYMBOL: 'USD',
+          ITRA_NIS: '317.29',
+          KVUTZAT_CHESHBON_CODE: '225',
+          KVUTZAT_CHESHBON_NAME: 'פמ"ח יחיד עו"ש',
+        },
+      ],
+      FCR_TRANS_DATA_ARR: [
+        {
+          TRANSACTION_DATE: '2026-09-06 00:00:00',
+          ERECH_DATE: '2026-09-03 00:00:00',
+          TEUR_TNUA_DESC: 'תקבול מט"ח',
+          SUG_ISKA_CODE: '442',
+          SUG_ISKA_DESC: 'פקודת יומן במט"ח',
+          ASMACHTA: '381',
+          TNUA_AMT: '104.96',
+          ITRA_CURRENT_AMT: '104.96',
+          MATBEA_CODE: '1',
+          TNUA_NUM: '1',
+          KABAH_CODE: '225',
+          KABAH_NAME: 'פמ"ח יחיד עו"ש',
+        },
+        placeholderTransaction,
+      ],
+      FCR_PENDING_TRANS_ARR: [placeholderTransaction],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].accountNumber).toBe('12345-USD');
+    expect(accounts[0].currency).toBe('USD');
+    expect(accounts[0].balance).toBe(104.96);
+    expect(accounts[0].txns).toHaveLength(1);
+    expect(accounts[0].txns[0]).toMatchObject({
+      identifier: 't1-381',
+      originalAmount: 104.96,
+      chargedAmount: 104.96,
+      originalCurrency: 'USD',
+      chargedCurrency: 'USD',
+      status: 'completed',
+    });
+    const expectedDate = moment('2026-09-06 00:00:00', 'YYYY-MM-DD HH:mm:ss').toISOString();
+    expect(accounts[0].txns[0].date).toBe(expectedDate);
+  });
+
+  test('parses a negative TNUA_AMT as a negative chargedAmount', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [usdAggregate()],
+      FCR_TRANS_DATA_ARR: [{ ...usdTransaction(), TNUA_AMT: '-50.25' }],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts[0].txns[0].chargedAmount).toBe(-50.25);
+  });
+
+  test('falls back processedDate to date when ERECH_DATE is empty', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [usdAggregate()],
+      FCR_TRANS_DATA_ARR: [{ ...usdTransaction(), ERECH_DATE: '' }],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts[0].txns[0].processedDate).toBe(accounts[0].txns[0].date);
+  });
+
+  test('returns no accounts for an empty aggregate array with only placeholder rows', () => {
+    const response = makeResponse({});
+
+    expect(convertForeignCurrencyAccounts('12345', response)).toEqual([]);
+  });
+
+  test('splits transactions across two currencies', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [
+        { ...usdAggregate() },
+        {
+          ITRAT_FCR_BOOKED: '50',
+          ITRAT_FCR_PENDING: '50',
+          MATBEA_CODE: '2',
+          MATBEA_NAME: 'אירו',
+          MATBEA_SHORT_NAME: 'אירו',
+          MATBEA_SYMBOL: 'EUR',
+          ITRA_NIS: '200',
+          KVUTZAT_CHESHBON_CODE: '226',
+          KVUTZAT_CHESHBON_NAME: 'פמ"ח יחיד עו"ש',
+        },
+      ],
+      FCR_TRANS_DATA_ARR: [usdTransaction(), eurTransaction()],
+      FCR_PENDING_TRANS_ARR: [usdPendingTransaction()],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts).toHaveLength(2);
+    const usdAccount = accounts.find(a => a.currency === 'USD');
+    const eurAccount = accounts.find(a => a.currency === 'EUR');
+    expect(usdAccount?.txns).toHaveLength(2);
+    expect(usdAccount?.txns[1].status).toBe('pending');
+    expect(usdAccount?.txns[1].identifier).toBeUndefined();
+    expect(eurAccount?.txns).toHaveLength(1);
+    expect(eurAccount?.txns[0].originalCurrency).toBe('EUR');
+  });
+
+  test('drops a transaction row with an unparsable amount', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [usdAggregate()],
+      FCR_TRANS_DATA_ARR: [{ ...usdTransaction(), TNUA_AMT: 'abc' }],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts[0].txns).toEqual([]);
+  });
+
+  test('drops a transaction row with an empty TRANSACTION_DATE', () => {
+    const response = makeResponse({
+      FCR_AGG_DATA_ARR: [usdAggregate()],
+      FCR_TRANS_DATA_ARR: [{ ...usdTransaction(), TRANSACTION_DATE: '' }],
+    });
+
+    const accounts = convertForeignCurrencyAccounts('12345', response);
+
+    expect(accounts[0].txns).toEqual([]);
+  });
+
+  function usdAggregate() {
+    return {
+      ITRAT_FCR_BOOKED: '104.96',
+      ITRAT_FCR_PENDING: '104.96',
+      MATBEA_CODE: '1',
+      MATBEA_NAME: 'דולר ארה"ב',
+      MATBEA_SHORT_NAME: 'דולר',
+      MATBEA_SYMBOL: 'USD',
+      ITRA_NIS: '317.29',
+      KVUTZAT_CHESHBON_CODE: '225',
+      KVUTZAT_CHESHBON_NAME: 'פמ"ח יחיד עו"ש',
+    };
+  }
+
+  function usdTransaction() {
+    return {
+      TRANSACTION_DATE: '2026-09-06 00:00:00',
+      ERECH_DATE: '2026-09-03 00:00:00',
+      TEUR_TNUA_DESC: 'תקבול מט"ח',
+      SUG_ISKA_CODE: '442',
+      SUG_ISKA_DESC: 'פקודת יומן במט"ח',
+      ASMACHTA: '381',
+      TNUA_AMT: '104.96',
+      ITRA_CURRENT_AMT: '104.96',
+      MATBEA_CODE: '1',
+      TNUA_NUM: '1',
+      KABAH_CODE: '225',
+      KABAH_NAME: 'פמ"ח יחיד עו"ש',
+    };
+  }
+
+  function usdPendingTransaction() {
+    return {
+      TRANSACTION_DATE: '2026-09-07 00:00:00',
+      ERECH_DATE: '',
+      SUG_ISKA_CODE: '442',
+      SUG_ISKA_DESC: 'המחאה בהמתנה',
+      ASMACHTA: '382',
+      TNUA_AMT: '10',
+      ITRA_CURRENT_AMT: '114.96',
+      MATBEA_CODE: '1',
+      TNUA_NUM: '1',
+      KABAH_CODE: '225',
+      KABAH_NAME: 'פמ"ח יחיד עו"ש',
+    };
+  }
+
+  function eurTransaction() {
+    return {
+      TRANSACTION_DATE: '2026-09-08 00:00:00',
+      ERECH_DATE: '2026-09-08 00:00:00',
+      TEUR_TNUA_DESC: 'תקבול מט"ח',
+      SUG_ISKA_CODE: '442',
+      SUG_ISKA_DESC: 'פקודת יומן במט"ח',
+      ASMACHTA: '500',
+      TNUA_AMT: '50',
+      ITRA_CURRENT_AMT: '50',
+      MATBEA_CODE: '2',
+      TNUA_NUM: '2',
+      KABAH_CODE: '226',
+      KABAH_NAME: 'פמ"ח יחיד עו"ש',
+    };
+  }
 });

--- a/src/scrapers/mizrahi.test.ts
+++ b/src/scrapers/mizrahi.test.ts
@@ -1,4 +1,4 @@
-import MizrahiScraper from './mizrahi';
+import MizrahiScraper, { parseAmount, scrapeAccounts, convertPendingRow } from './mizrahi';
 import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
 import { SCRAPERS } from '../definitions';
 import { ISO_DATE_REGEX } from '../constants';
@@ -65,5 +65,213 @@ describe('Mizrahi scraper', () => {
     expect(account.txns[0].date).toMatch(ISO_DATE_REGEX);
 
     exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});
+
+describe('parseAmount', () => {
+  test('parses an integer string', () => {
+    expect(parseAmount('12345')).toBe(12345);
+  });
+
+  test('parses a string with thousands separators', () => {
+    expect(parseAmount('12,345.67')).toBe(12345.67);
+  });
+
+  test('parses a negative value', () => {
+    expect(parseAmount('-1,234.5')).toBe(-1234.5);
+  });
+
+  test('strips a leading currency symbol', () => {
+    expect(parseAmount('₪1,234.5')).toBe(1234.5);
+  });
+
+  test('strips a trailing currency symbol', () => {
+    expect(parseAmount('1,234.5 ₪')).toBe(1234.5);
+  });
+
+  test('returns undefined for an empty string', () => {
+    expect(parseAmount('')).toBeUndefined();
+  });
+
+  test('returns undefined for undefined', () => {
+    expect(parseAmount(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for null', () => {
+    expect(parseAmount(null)).toBeUndefined();
+  });
+
+  test('returns undefined for garbage input', () => {
+    expect(parseAmount('abc')).toBeUndefined();
+  });
+
+  test('applies the sign for a trailing minus', () => {
+    expect(parseAmount('1,234.56-')).toBe(-1234.56);
+  });
+
+  test('applies the sign for parenthesized negatives', () => {
+    expect(parseAmount('(1,234.56)')).toBe(-1234.56);
+  });
+
+  test('applies the sign for a leading minus with a thousands separator', () => {
+    expect(parseAmount('-1,234.56')).toBe(-1234.56);
+  });
+
+  test('strips bidi marks around the amount', () => {
+    expect(parseAmount('‏1,234.56‎')).toBe(1234.56);
+  });
+
+  test('returns undefined for a lone minus sign', () => {
+    expect(parseAmount('-')).toBeUndefined();
+  });
+
+  test('returns undefined for whitespace-only input', () => {
+    expect(parseAmount('   ')).toBeUndefined();
+  });
+
+  test('returns undefined for a minus sign embedded in letters', () => {
+    expect(parseAmount('abc-5')).toBeUndefined();
+  });
+
+  test('returns undefined for a minus sign embedded between digits', () => {
+    expect(parseAmount('12-34')).toBeUndefined();
+  });
+
+  test('returns undefined for a value with multiple decimal points', () => {
+    expect(parseAmount('1.2.3')).toBeUndefined();
+  });
+
+  test('returns undefined for exponential notation', () => {
+    expect(parseAmount('1e5')).toBeUndefined();
+  });
+
+  test('parses a leading-dot decimal', () => {
+    expect(parseAmount('.5')).toBe(0.5);
+  });
+
+  test('parses a realistic Yitra-like balance string', () => {
+    expect(parseAmount('12,345.67 ₪')).toBe(12345.67);
+  });
+
+  test('strips a leading currency symbol with a leading minus', () => {
+    expect(parseAmount('₪ -12')).toBe(-12);
+  });
+
+  test('strips a trailing currency symbol with a trailing minus', () => {
+    expect(parseAmount('12- ₪')).toBe(-12);
+  });
+
+  test('maps a unicode minus sign after the amount', () => {
+    expect(parseAmount('1,234.56−')).toBe(-1234.56);
+  });
+
+  test('returns undefined for Hebrew text preceding the amount', () => {
+    expect(parseAmount('יתרת חובה 1,234.56')).toBeUndefined();
+  });
+
+  test('returns undefined for Hebrew text following the amount', () => {
+    expect(parseAmount('1,234.56 חובה')).toBeUndefined();
+  });
+
+  test('returns undefined for multiple parenthesized groups', () => {
+    expect(parseAmount('(1)+(2)')).toBeUndefined();
+  });
+});
+
+describe('convertPendingRow', () => {
+  test('parses a debit row as a negative amount', () => {
+    const txn = convertPendingRow(['15/09/26', 'חיוב ויזה כאל עתידי', "ש''ח", '', '6,883.17', '1', '002', '']);
+    expect(txn?.chargedAmount).toBe(-6883.17);
+    expect(txn?.status).toBe('pending');
+  });
+
+  test('parses a credit row as a positive amount', () => {
+    const txn = convertPendingRow(['10/09/26', 'desc', "ש''ח", '250.00', '', '1', '001', '']);
+    expect(txn?.chargedAmount).toBe(250);
+  });
+
+  test('returns undefined for a row with an empty date', () => {
+    const txn = convertPendingRow(['', 'desc', "ש''ח", '', '6,883.17', '1', '002', '']);
+    expect(txn).toBeUndefined();
+  });
+
+  test('returns undefined for a row with no parsable amount', () => {
+    const txn = convertPendingRow(['15/09/26', 'desc', "ש''ח", '', '', '1', '002', '']);
+    expect(txn).toBeUndefined();
+  });
+});
+
+describe('scrapeAccounts', () => {
+  function makeAccount(accountNumber: string): TransactionsAccount {
+    return { accountNumber, txns: [] };
+  }
+
+  test('keeps the accounts that succeed when one account throws', async () => {
+    const selectAccount = jest.fn().mockResolvedValue(undefined);
+    const fetchAccount = jest.fn().mockImplementation((index: number) => {
+      if (index === 1) {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(makeAccount(`acc-${index}`));
+    });
+
+    const { accounts, errors } = await scrapeAccounts(3, selectAccount, fetchAccount);
+
+    expect(accounts).toEqual([makeAccount('acc-0'), makeAccount('acc-2')]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('boom');
+    expect(selectAccount).toHaveBeenCalledTimes(3);
+  });
+
+  test('returns an error message for every account when all of them throw', async () => {
+    const selectAccount = jest.fn().mockResolvedValue(undefined);
+    const fetchAccount = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockRejectedValueOnce(new Error('second failure'));
+
+    const { accounts, errors } = await scrapeAccounts(2, selectAccount, fetchAccount);
+
+    expect(accounts).toEqual([]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('first failure');
+    expect(errors[1]).toContain('second failure');
+  });
+
+  test('unwraps AggregateError into readable per-error messages', async () => {
+    const selectAccount = jest.fn().mockResolvedValue(undefined);
+    const aggregate = new AggregateError([new Error('inner one'), new Error('inner two')], 'all promises rejected');
+    const fetchAccount = jest.fn().mockRejectedValue(aggregate);
+
+    const { accounts, errors } = await scrapeAccounts(1, selectAccount, fetchAccount);
+
+    expect(accounts).toEqual([]);
+    expect(errors[0]).toContain('inner one');
+    expect(errors[0]).toContain('inner two');
+  });
+
+  test('recurses into a nested AggregateError', async () => {
+    const selectAccount = jest.fn().mockResolvedValue(undefined);
+    const inner = new AggregateError([new Error('deep one'), new Error('deep two')], 'inner aggregate');
+    const outer = new AggregateError([inner, new Error('shallow')], 'outer aggregate');
+    const fetchAccount = jest.fn().mockRejectedValue(outer);
+
+    const { errors } = await scrapeAccounts(1, selectAccount, fetchAccount);
+
+    expect(errors[0]).toContain('deep one');
+    expect(errors[0]).toContain('deep two');
+    expect(errors[0]).toContain('shallow');
+  });
+
+  test('falls back to the error itself for an empty AggregateError', async () => {
+    const selectAccount = jest.fn().mockResolvedValue(undefined);
+    const aggregate = new AggregateError([], 'nothing succeeded');
+    const fetchAccount = jest.fn().mockRejectedValue(aggregate);
+
+    const { accounts, errors } = await scrapeAccounts(1, selectAccount, fetchAccount);
+
+    expect(accounts).toEqual([]);
+    expect(errors[0]).toBe(`account #1: ${String(aggregate)}`);
+    expect(errors[0]).not.toMatch(/account #1: $/);
   });
 });

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -74,6 +74,51 @@ type MoreDetails = {
   memo: string | undefined;
 };
 
+interface ForeignCurrencyAggregate {
+  ITRAT_FCR_BOOKED: string;
+  ITRAT_FCR_PENDING: string;
+  MATBEA_CODE: string;
+  MATBEA_NAME: string;
+  MATBEA_SHORT_NAME: string;
+  MATBEA_SYMBOL: string;
+  ITRA_NIS: string;
+  KVUTZAT_CHESHBON_CODE: string;
+  KVUTZAT_CHESHBON_NAME: string;
+}
+
+interface ForeignCurrencyTransaction {
+  TRANSACTION_DATE: string;
+  ERECH_DATE: string;
+  TEUR_TNUA_DESC?: string;
+  SUG_ISKA_CODE: string;
+  SUG_ISKA_DESC: string;
+  ASMACHTA: string;
+  TNUA_AMT: string;
+  ITRA_CURRENT_AMT: string;
+  MATBEA_CODE: string;
+  TNUA_NUM: string;
+  KABAH_CODE: string;
+  KABAH_NAME: string;
+}
+
+interface ForeignCurrencyResponse {
+  header: {
+    success: boolean | null;
+    messages: { text: string }[];
+  };
+  body: {
+    table: {
+      rows: {
+        RET_MESSAGE: string;
+        RET_CODE: string;
+        FCR_AGG_DATA_ARR: ForeignCurrencyAggregate[];
+        FCR_TRANS_DATA_ARR: ForeignCurrencyTransaction[];
+        FCR_PENDING_TRANS_ARR: ForeignCurrencyTransaction[];
+      };
+    };
+  };
+}
+
 const BASE_WEBSITE_URL = 'https://www.mizrahi-tefahot.co.il';
 const LOGIN_URL = `${BASE_WEBSITE_URL}/login/index.html#/auth-page-he`;
 const BASE_APP_URL = 'https://mto.mizrahi-tefahot.co.il';
@@ -86,9 +131,16 @@ const TRANSACTIONS_REQUEST_URLS = [
 ];
 const PENDING_TRANSACTIONS_PAGE = '/osh/legacy/legacy-Osh-p420';
 const PENDING_TRANSACTIONS_IFRAME = 'p420.aspx';
+const FOREIGN_CURRENCY_PAGE = '/osh/matachYetrotVeTnuot';
+const FOREIGN_CURRENCY_REQUEST_URLS = [
+  `${BASE_APP_URL}/Online/api/mth/getMatachTnuotYetrot`,
+  `${BASE_APP_URL}/OnlinePilot/api/mth/getMatachTnuotYetrot`,
+];
 const MORE_DETAILS_URL = `${BASE_APP_URL}/Online/api/OSH/getMaherBerurimSMF`;
 const CHANGE_PASSWORD_URL = /https:\/\/www\.mizrahi-tefahot\.co\.il\/login\/index\.html#\/change-pass/;
 const DATE_FORMAT = 'DD/MM/YYYY';
+const FOREIGN_CURRENCY_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+const ALL_CURRENCIES_CODE = '999';
 const MAX_ROWS_PER_REQUEST = 10000000000;
 
 const usernameSelector = '#userNumberDesktopHeb';
@@ -322,6 +374,98 @@ async function extractPendingTransactions(page: Frame): Promise<Transaction[]> {
   });
 }
 
+function buildForeignCurrencyTransaction(
+  row: ForeignCurrencyTransaction,
+  currency: string,
+  identifier: string | undefined,
+  description: string,
+  status: TransactionStatuses,
+  options?: ScraperOptions,
+): Transaction | undefined {
+  const amount = parseAmount(row.TNUA_AMT);
+  if (amount === undefined) {
+    debug(`Dropping foreign currency transaction with unparsable amount. TNUA_AMT: ${row.TNUA_AMT}`);
+    return undefined;
+  }
+
+  const date = moment(row.TRANSACTION_DATE, FOREIGN_CURRENCY_DATE_FORMAT).toISOString();
+  if (!date) {
+    debug(`Dropping foreign currency transaction with unparsable date. TRANSACTION_DATE: ${row.TRANSACTION_DATE}`);
+    return undefined;
+  }
+
+  const processedDate = row.ERECH_DATE ? moment(row.ERECH_DATE, FOREIGN_CURRENCY_DATE_FORMAT).toISOString() : date;
+
+  const transaction: Transaction = {
+    type: TransactionTypes.Normal,
+    identifier,
+    date,
+    processedDate,
+    originalAmount: amount,
+    originalCurrency: currency,
+    chargedAmount: amount,
+    chargedCurrency: currency,
+    description,
+    status,
+  };
+
+  if (options?.includeRawTransaction) {
+    transaction.rawTransaction = getRawTransaction(row);
+  }
+
+  return transaction;
+}
+
+export function convertForeignCurrencyAccounts(
+  accountNumber: string,
+  response: ForeignCurrencyResponse,
+  options?: ScraperOptions,
+): TransactionsAccount[] {
+  const rows = response.body?.table?.rows;
+  const aggregates = rows?.FCR_AGG_DATA_ARR ?? [];
+
+  return aggregates
+    .filter(aggregate => !!aggregate.MATBEA_SYMBOL)
+    .map(aggregate => {
+      const currency = aggregate.MATBEA_SYMBOL;
+
+      const bookedTxns = (rows.FCR_TRANS_DATA_ARR ?? [])
+        .filter(row => row.MATBEA_CODE === aggregate.MATBEA_CODE)
+        .flatMap(row => {
+          const txn = buildForeignCurrencyTransaction(
+            row,
+            currency,
+            `t${row.TNUA_NUM}-${row.ASMACHTA}`,
+            row.TEUR_TNUA_DESC || row.SUG_ISKA_DESC || '',
+            TransactionStatuses.Completed,
+            options,
+          );
+          return txn ? [txn] : [];
+        });
+
+      const pendingTxns = (rows.FCR_PENDING_TRANS_ARR ?? [])
+        .filter(row => row.MATBEA_CODE === aggregate.MATBEA_CODE)
+        .flatMap(row => {
+          const txn = buildForeignCurrencyTransaction(
+            row,
+            currency,
+            undefined,
+            row.TEUR_TNUA_DESC || row.SUG_ISKA_DESC || '',
+            TransactionStatuses.Pending,
+            options,
+          );
+          return txn ? [txn] : [];
+        });
+
+      return {
+        accountNumber: `${accountNumber}-${currency}`,
+        currency,
+        balance: parseAmount(aggregate.ITRAT_FCR_BOOKED),
+        txns: bookedTxns.concat(pendingTxns),
+      };
+    });
+}
+
 function describeError(error: unknown): string {
   if (error instanceof AggregateError) {
     if (error.errors.length === 0) {
@@ -335,7 +479,7 @@ function describeError(error: unknown): string {
 export async function scrapeAccounts(
   numOfAccounts: number,
   selectAccount: (index: number) => Promise<void>,
-  fetchAccount: (index: number) => Promise<TransactionsAccount>,
+  fetchAccount: (index: number) => Promise<TransactionsAccount[]>,
 ): Promise<{ accounts: TransactionsAccount[]; errors: string[] }> {
   const accounts: TransactionsAccount[] = [];
   const errors: string[] = [];
@@ -343,7 +487,8 @@ export async function scrapeAccounts(
   for (let i = 0; i < numOfAccounts; i += 1) {
     try {
       await selectAccount(i);
-      accounts.push(await fetchAccount(i));
+      const result = await fetchAccount(i);
+      accounts.push(...result);
     } catch (e) {
       const message = `account #${i + 1}: ${describeError(e)}`;
       debug(`Failed to fetch account: ${message}`);
@@ -391,7 +536,11 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
           (el as HTMLElement).click(),
         );
       },
-      () => this.fetchAccount(),
+      async () => {
+        const account = await this.fetchAccount();
+        const foreignCurrencyAccounts = await this.fetchForeignCurrencyAccounts(account.accountNumber);
+        return [account, ...foreignCurrencyAccounts];
+      },
     );
 
     if (accounts.length === 0 && errors.length > 0) {
@@ -479,6 +628,52 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       txns: allTxn,
       balance: parseAmount(response.body.fields?.Yitra),
     };
+  }
+
+  private async fetchForeignCurrencyAccounts(accountNumber: string): Promise<TransactionsAccount[]> {
+    try {
+      const linkSelector = `a[href*="${FOREIGN_CURRENCY_PAGE}"]`;
+      if (!(await this.page.$(linkSelector))) {
+        debug('no foreign currency link, skipping');
+        return [];
+      }
+
+      const requestPromise = Promise.any(
+        FOREIGN_CURRENCY_REQUEST_URLS.map(async url => ({
+          url,
+          request: await this.page.waitForRequest(url, { timeout: 15000 }),
+        })),
+      );
+      requestPromise.catch(() => undefined);
+
+      await this.page.$eval(linkSelector, el => (el as HTMLElement).click());
+
+      const { url, request } = await requestPromise;
+      const data = JSON.parse(request.postData() || '{}');
+      data.startDate = getStartMoment(this.options.startDate).format(DATE_FORMAT);
+      data.endDate = moment().format(DATE_FORMAT);
+      data.codeMatbea = ALL_CURRENCIES_CODE;
+      const headers = createHeadersFromRequest(request);
+
+      const response = await fetchPostWithinPage<ForeignCurrencyResponse>(this.page, url, data, headers);
+
+      const rows = response?.body?.table?.rows;
+      if (response?.header.messages?.length) {
+        debug('foreign currency accounts response messages:', response.header.messages);
+      }
+      if (!response || rows?.RET_CODE !== '1') {
+        throw new Error(
+          `Error fetching foreign currency accounts. Response message: ${
+            response?.header.messages?.[0]?.text ?? rows?.RET_MESSAGE ?? ''
+          }`,
+        );
+      }
+
+      return convertForeignCurrencyAccounts(accountNumber, response, this.options);
+    } catch (error) {
+      debug(`Failed to fetch foreign currency accounts for account ${accountNumber}: ${describeError(error)}`);
+      return [];
+    }
   }
 
   private shouldMarkAsPending(txn: Transaction): boolean {

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -322,6 +322,38 @@ async function extractPendingTransactions(page: Frame): Promise<Transaction[]> {
   });
 }
 
+function describeError(error: unknown): string {
+  if (error instanceof AggregateError) {
+    if (error.errors.length === 0) {
+      return String(error);
+    }
+    return error.errors.map(describeError).join('; ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function scrapeAccounts(
+  numOfAccounts: number,
+  selectAccount: (index: number) => Promise<void>,
+  fetchAccount: (index: number) => Promise<TransactionsAccount>,
+): Promise<{ accounts: TransactionsAccount[]; errors: string[] }> {
+  const accounts: TransactionsAccount[] = [];
+  const errors: string[] = [];
+
+  for (let i = 0; i < numOfAccounts; i += 1) {
+    try {
+      await selectAccount(i);
+      accounts.push(await fetchAccount(i));
+    } catch (e) {
+      const message = `account #${i + 1}: ${describeError(e)}`;
+      debug(`Failed to fetch account: ${message}`);
+      errors.push(message);
+    }
+  }
+
+  return { accounts, errors };
+}
+
 async function postLogin(page: Page) {
   await Promise.race([
     waitUntilElementFound(page, afterLoginSelector),
@@ -349,29 +381,31 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
 
     const numOfAccounts = (await this.page.$$(accountDropDownItemSelector)).length;
 
-    try {
-      const results: TransactionsAccount[] = [];
-
-      for (let i = 0; i < numOfAccounts; i += 1) {
-        if (i > 0) {
+    const { accounts, errors } = await scrapeAccounts(
+      numOfAccounts,
+      async index => {
+        if (index > 0) {
           await this.page.$eval('#dropdownBasic, .item', el => (el as HTMLElement).click());
         }
+        await this.page.$eval(`${accountDropDownItemSelector}:nth-child(${index + 1})`, el =>
+          (el as HTMLElement).click(),
+        );
+      },
+      () => this.fetchAccount(),
+    );
 
-        await this.page.$eval(`${accountDropDownItemSelector}:nth-child(${i + 1})`, el => (el as HTMLElement).click());
-        results.push(await this.fetchAccount());
-      }
-
-      return {
-        success: true,
-        accounts: results,
-      };
-    } catch (e) {
+    if (accounts.length === 0 && errors.length > 0) {
       return {
         success: false,
         errorType: ScraperErrorTypes.Generic,
-        errorMessage: (e as Error).message,
+        errorMessage: errors.join('; '),
       };
     }
+
+    return {
+      success: true,
+      accounts,
+    };
   }
 
   private async getPendingTransactions(): Promise<Transaction[]> {

--- a/src/scrapers/mizrahi.ts
+++ b/src/scrapers/mizrahi.ts
@@ -199,6 +199,42 @@ function createHeadersFromRequest(request: HTTPRequest) {
   };
 }
 
+const STRIP_REGEX = /[,\s\u20aa$\u20ac\u200e\u200f\u202a-\u202e]/g;
+const PAREN_REGEX = /^\((.+)\)$/;
+const UNSIGNED_AMOUNT_REGEX = /^\d*\.?\d+$/;
+
+export function parseAmount(raw: string | undefined | null): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const cleaned = raw.replace(STRIP_REGEX, '').replace(/\u2212/g, '-');
+  if (!cleaned) {
+    return undefined;
+  }
+
+  const parenMatch = cleaned.match(PAREN_REGEX);
+  let unsigned = cleaned;
+  let isNegative = false;
+  if (parenMatch) {
+    isNegative = true;
+    unsigned = parenMatch[1];
+  } else if (cleaned.startsWith('-')) {
+    isNegative = true;
+    unsigned = cleaned.slice(1);
+  } else if (cleaned.endsWith('-')) {
+    isNegative = true;
+    unsigned = cleaned.slice(0, -1);
+  }
+
+  if (!UNSIGNED_AMOUNT_REGEX.test(unsigned)) {
+    return undefined;
+  }
+
+  const value = parseFloat(unsigned);
+  return isNegative ? -value : value;
+}
+
 function getTransactionIdentifier(row: ScrapedTransaction): string | number | undefined {
   if (!row.MC02AsmahtaMekoritEZ) {
     return undefined;
@@ -249,29 +285,41 @@ async function convertTransactions(
   );
 }
 
+export function convertPendingRow(cells: string[]): Transaction | undefined {
+  const [dateStr, description, , creditStr, debitStr] = cells;
+  const date = moment(dateStr, 'DD/MM/YY').toISOString();
+  const debit = parseAmount(debitStr);
+  const credit = parseAmount(creditStr);
+  const amount = debit !== undefined ? -debit : credit;
+
+  if (!date || amount === undefined) {
+    debug(
+      `Dropping pending transaction with unparsable date or amount. dateStr: ${dateStr}, description: ${description}, creditStr: ${creditStr}, debitStr: ${debitStr}`,
+    );
+    return undefined;
+  }
+
+  return {
+    type: TransactionTypes.Normal,
+    date,
+    processedDate: date,
+    originalAmount: amount,
+    originalCurrency: SHEKEL_CURRENCY,
+    chargedAmount: amount,
+    description,
+    status: TransactionStatuses.Pending,
+  };
+}
+
 async function extractPendingTransactions(page: Frame): Promise<Transaction[]> {
   const pendingTxn = await pageEvalAll(page, 'tr.rgRow, tr.rgAltRow', [], trs => {
     return trs.map(tr => Array.from(tr.querySelectorAll('td'), td => td.textContent || ''));
   });
 
-  return pendingTxn
-    .map(([dateStr, description, incomeAmountStr, amountStr]) => ({
-      date: moment(dateStr, 'DD/MM/YY').toISOString(),
-      amount: parseFloat(amountStr.replaceAll(',', '')),
-      description,
-      incomeAmountStr, // TODO: handle incomeAmountStr once we know the sign of it
-    }))
-    .filter(txn => txn.date)
-    .map(({ date, description, amount }) => ({
-      type: TransactionTypes.Normal,
-      date,
-      processedDate: date,
-      originalAmount: amount,
-      originalCurrency: SHEKEL_CURRENCY,
-      chargedAmount: amount,
-      description,
-      status: TransactionStatuses.Pending,
-    }));
+  return pendingTxn.flatMap(cells => {
+    const txn = convertPendingRow(cells);
+    return txn ? [txn] : [];
+  });
 }
 
 async function postLogin(page: Page) {
@@ -395,7 +443,7 @@ class MizrahiScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     return {
       accountNumber,
       txns: allTxn,
-      balance: +response.body.fields?.Yitra,
+      balance: parseAmount(response.body.fields?.Yitra),
     };
   }
 


### PR DESCRIPTION
Changes:
- Parse the Mizrahi account balance instead of `+fields.Yitra`, which produced `NaN` for every account. New `parseAmount()` handles thousands separators, currency symbols, bidi marks, leading/trailing minus and parenthesized negatives, and rejects anything else. Closes #1168
- Fix the pending-transactions column mapping: the table has a currency column, so the code was reading the empty credit cell as the amount and every pending row came back with `NaN`. Credit/debit are now read from the right cells and signed (debit negative). Rows without a parsable date or amount are dropped with a debug log.
- Isolate per-account failures in `fetchData`: one unscrapable account no longer discards the others. The scrape returns `success: true` with the accounts that worked (failures in debug logs), and `success: false` with per-account messages only if every account failed. Fixes #1156
- Add foreign currency (פמ"ח) accounts, one `TransactionsAccount` per currency, named `<account>-<ISO>` (e.g. `449-271199-USD`) with `currency` set and both `originalCurrency`/`chargedCurrency` on transactions. Additive and isolated: any failure in the FX step returns no FX accounts and never affects the ILS result. No opt-in flag, following the Leumi FX precedent (#1149). Closes #1169

How the foreign currency flow works (discovered against a live account):
- The FX account is **not** an entry in `#AccountPicker`, contrary to the issue's premise. It lives under the sidebar section עו"ש מט"ח → יתרה ותנועות במט"ח, route `/OnlineApp/osh/matachYetrotVeTnuot` (native Angular page, no iframe).
- Navigating there fires `POST /Online/api/mth/getMatachTnuotYetrot` with `{"codeMatbea":"999","startDate":"DD/MM/YYYY","endDate":"DD/MM/YYYY"}` (999 = all currencies). The scraper captures that request and replays it with the requested start date, the same capture-and-replay pattern as the ILS `get428Index` flow.
- Response: `FCR_AGG_DATA_ARR` (one entry per currency: `MATBEA_SYMBOL`, `ITRAT_FCR_BOOKED`, `ITRA_NIS`, ...), `FCR_TRANS_DATA_ARR` and `FCR_PENDING_TRANS_ARR` (dates `YYYY-MM-DD HH:mm:ss`, `TNUA_AMT`, running balance `ITRA_CURRENT_AMT`). Empty arrays contain a single all-empty placeholder row; rows are matched to their currency by `MATBEA_CODE`, which also drops the placeholder.
- Two things that only showed up live: the request waiters must be armed before the click (the XHR fires within milliseconds on this route), and the click must be a dispatched DOM click, since the sidebar link sits below the default viewport and a puppeteer mouse click silently does nothing.

Verification:
- Unit tests for `parseAmount`, `convertPendingRow`, `scrapeAccounts` and `convertForeignCurrencyAccounts` (44 tests, no credentials needed). Full suite green, lint and type-check clean.
- Verified against a real Mizrahi account: ILS account with correct balance and 15 transactions including a pending one with a real amount; USD account with correct balance and its transaction; full scrape ~7s.
- Caveats: the test account is a single-account login, so the multi-account picker loop after the FX page was not exercised live. Only a credit FX transaction was available; FX amounts are used as returned by the API, which the bank's own UI also renders without any sign handling, same as the ILS endpoint where debits arrive negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKZAF2i1e2BBtiqtLTbtoZ
