### PR TITLE
fix(visa-cal): dedupe pending transactions that duplicate a completed one

### DIFF
--- a/src/scrapers/visa-cal.test.ts
+++ b/src/scrapers/visa-cal.test.ts
@@ -71,11 +71,11 @@ describe('VisaCal legacy scraper', () => {
 describe('dedupePendingTransactions', () => {
   test('drops a pending transaction once an identical completed counterpart exists', () => {
     const transactions = [
-      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:20:05.000Z', chargedAmount: -450 }),
+      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:20:05.000Z', chargedAmount: -120 }),
       makeTransaction({
         status: TransactionStatuses.Completed,
         date: '2024-05-10T07:20:05.000Z',
-        chargedAmount: -450,
+        chargedAmount: -120,
         identifier: 'abc123',
       }),
     ];
@@ -92,12 +92,12 @@ describe('dedupePendingTransactions', () => {
       makeTransaction({
         status: TransactionStatuses.Pending,
         date: '2024-05-10T05:09:27.000Z',
-        chargedAmount: -299, // placeholder hold amount
+        chargedAmount: -200, // placeholder hold amount
       }),
       makeTransaction({
         status: TransactionStatuses.Completed,
         date: '2024-05-10T05:12:18.000Z', // a few minutes later, once the pump total is known
-        chargedAmount: -152.72,
+        chargedAmount: -84.3,
         identifier: 'abc456',
       }),
     ];
@@ -106,16 +106,16 @@ describe('dedupePendingTransactions', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].status).toBe(TransactionStatuses.Completed);
-    expect(result[0].chargedAmount).toBe(-152.72);
+    expect(result[0].chargedAmount).toBe(-84.3);
   });
 
   test('drops the pending side when the amount differs by a small settlement adjustment', () => {
     const transactions = [
-      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:29:25.000Z', chargedAmount: -250.3 }),
+      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:29:25.000Z', chargedAmount: -75.5 }),
       makeTransaction({
         status: TransactionStatuses.Completed,
         date: '2024-05-10T07:29:25.000Z',
-        chargedAmount: -251,
+        chargedAmount: -76,
         identifier: 'abc789',
       }),
     ];
@@ -123,7 +123,7 @@ describe('dedupePendingTransactions', () => {
     const result = dedupePendingTransactions(transactions);
 
     expect(result).toHaveLength(1);
-    expect(result[0].chargedAmount).toBe(-251);
+    expect(result[0].chargedAmount).toBe(-76);
   });
 
   test('keeps a pending transaction with no completed counterpart', () => {

--- a/src/scrapers/visa-cal.test.ts
+++ b/src/scrapers/visa-cal.test.ts
@@ -1,10 +1,25 @@
 import { SCRAPERS } from '../definitions';
 import { exportTransactions, extendAsyncTimeout, getTestsConfig, maybeTestCompanyAPI } from '../tests/tests-utils';
+import { TransactionStatuses, TransactionTypes, type Transaction } from '../transactions';
 import { LoginResults } from './base-scraper-with-browser';
-import VisaCalScraper from './visa-cal';
+import VisaCalScraper, { dedupePendingTransactions } from './visa-cal';
 
 const COMPANY_ID = 'visaCal'; // TODO this property should be hard-coded in the provider
 const testsConfig = getTestsConfig();
+
+function makeTransaction(overrides: Partial<Transaction>): Transaction {
+  return {
+    type: TransactionTypes.Normal,
+    date: '2024-05-10T07:00:00.000Z',
+    processedDate: '2024-05-10T07:00:00.000Z',
+    originalAmount: -100,
+    originalCurrency: '₪',
+    chargedAmount: -100,
+    description: 'Test Merchant',
+    status: TransactionStatuses.Completed,
+    ...overrides,
+  };
+}
 
 describe('VisaCal legacy scraper', () => {
   beforeAll(() => {
@@ -50,5 +65,131 @@ describe('VisaCal legacy scraper', () => {
     // uncomment to test multiple accounts
     // expect(result?.accounts?.length).toEqual(2)
     exportTransactions(COMPANY_ID, result.accounts || []);
+  });
+});
+
+describe('dedupePendingTransactions', () => {
+  test('drops a pending transaction once an identical completed counterpart exists', () => {
+    const transactions = [
+      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:20:05.000Z', chargedAmount: -450 }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-10T07:20:05.000Z',
+        chargedAmount: -450,
+        identifier: 'abc123',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe(TransactionStatuses.Completed);
+    expect(result[0].identifier).toBe('abc123');
+  });
+
+  test('drops the pending side even when the amount differs (e.g. a gas-station pending hold)', () => {
+    const transactions = [
+      makeTransaction({
+        status: TransactionStatuses.Pending,
+        date: '2024-05-10T05:09:27.000Z',
+        chargedAmount: -299, // placeholder hold amount
+      }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-10T05:12:18.000Z', // a few minutes later, once the pump total is known
+        chargedAmount: -152.72,
+        identifier: 'abc456',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe(TransactionStatuses.Completed);
+    expect(result[0].chargedAmount).toBe(-152.72);
+  });
+
+  test('drops the pending side when the amount differs by a small settlement adjustment', () => {
+    const transactions = [
+      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T07:29:25.000Z', chargedAmount: -250.3 }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-10T07:29:25.000Z',
+        chargedAmount: -251,
+        identifier: 'abc789',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].chargedAmount).toBe(-251);
+  });
+
+  test('keeps a pending transaction with no completed counterpart', () => {
+    const transactions = [
+      makeTransaction({
+        status: TransactionStatuses.Pending,
+        date: '2024-05-11T09:00:00.000Z',
+        description: 'Coffee Shop',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe(TransactionStatuses.Pending);
+  });
+
+  test('pairs two same-day pending transactions at the same merchant with their own closest completed counterpart', () => {
+    const transactions = [
+      makeTransaction({
+        status: TransactionStatuses.Pending,
+        date: '2024-05-05T08:00:00.000Z',
+        description: 'Supermarket',
+        chargedAmount: -50,
+      }),
+      makeTransaction({
+        status: TransactionStatuses.Pending,
+        date: '2024-05-05T18:00:00.000Z',
+        description: 'Supermarket',
+        chargedAmount: -80,
+      }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-05T08:00:05.000Z',
+        description: 'Supermarket',
+        chargedAmount: -50,
+        identifier: 'morning',
+      }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-05T18:00:10.000Z',
+        description: 'Supermarket',
+        chargedAmount: -80,
+        identifier: 'evening',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(t => t.identifier).sort()).toEqual(['evening', 'morning']);
+  });
+
+  test('does not match pending and completed transactions on different days', () => {
+    const transactions = [
+      makeTransaction({ status: TransactionStatuses.Pending, date: '2024-05-10T23:59:00.000Z', chargedAmount: -50 }),
+      makeTransaction({
+        status: TransactionStatuses.Completed,
+        date: '2024-05-11T00:01:00.000Z',
+        chargedAmount: -50,
+        identifier: 'nextday',
+      }),
+    ];
+
+    const result = dedupePendingTransactions(transactions);
+
+    expect(result).toHaveLength(2);
   });
 });

--- a/src/scrapers/visa-cal.ts
+++ b/src/scrapers/visa-cal.ts
@@ -395,6 +395,47 @@ function convertParsedDataToTransactions(
   });
 }
 
+/**
+ * Visa Cal can report the same charge twice: once from the "pending authorizations" endpoint
+ * and once from the completed monthly-transactions endpoint, when a charge clears around the
+ * time of the fetch. The amount can differ between the two - a gas-station pending hold is a
+ * placeholder until the pump total is known, and other merchants adjust slightly on settlement -
+ * so this matches on description + calendar day + closest timestamp rather than an exact amount,
+ * and drops the pending entry once a completed counterpart is found. Matching is 1:1 so a second,
+ * still-genuinely-pending charge at the same merchant on the same day isn't dropped incorrectly.
+ */
+export function dedupePendingTransactions(transactions: Transaction[]): Transaction[] {
+  const pending = transactions.filter(t => t.status === TransactionStatuses.Pending);
+  const completed = transactions.filter(t => t.status !== TransactionStatuses.Pending);
+  const usedCompletedIndexes = new Set<number>();
+  const keptPending: Transaction[] = [];
+
+  for (const p of pending) {
+    const pendingDay = p.date.slice(0, 10);
+    let matchIndex = -1;
+    let matchGapMs = Infinity;
+
+    completed.forEach((c, idx) => {
+      if (usedCompletedIndexes.has(idx)) return;
+      if (c.description !== p.description) return;
+      if (c.date.slice(0, 10) !== pendingDay) return;
+      const gapMs = Math.abs(new Date(c.date).getTime() - new Date(p.date).getTime());
+      if (gapMs < matchGapMs) {
+        matchGapMs = gapMs;
+        matchIndex = idx;
+      }
+    });
+
+    if (matchIndex !== -1) {
+      usedCompletedIndexes.add(matchIndex);
+    } else {
+      keptPending.push(p);
+    }
+  }
+
+  return [...keptPending, ...completed];
+}
+
 type ScraperSpecificCredentials = { username: string; password: string };
 
 class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
@@ -599,7 +640,9 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       pendingData = null;
     }
 
-    const transactions = convertParsedDataToTransactions(allMonthsData, pendingData, this.options);
+    const transactions = dedupePendingTransactions(
+      convertParsedDataToTransactions(allMonthsData, pendingData, this.options),
+    );
 
     debug('filter out old transactions');
     const txns =


### PR DESCRIPTION
## Problem

Visa Cal's API can return the same real-world charge twice in a single scrape: once from the pending-authorizations endpoint (`getClearanceRequests`) and once from the completed monthly-transactions endpoint (`getCardTransactionsDetails`), when a charge clears right around the time of the fetch.

Observed patterns while using this scraper on a real account:

- A charge appeared as both `pending` and `completed`, same timestamp, same amount — an exact duplicate.
- A charge appeared as `pending` with one amount and, a few minutes later, as `completed` with a noticeably different (lower) amount — consistent with a merchant that posts a placeholder pending hold before the final total is known (e.g. a fuel pump; Cal's own transaction `memo` field on that record literally read "amount will be shown once the transaction is processed").
- A charge appeared as `pending` and `completed` with a slightly different amount — consistent with a minor settlement adjustment between authorization and posting.

The last two cases mean a simple exact-match dedupe (same date + description + amount) isn't sufficient — the amount can legitimately differ between the pending and completed record of the *same* transaction.

Downstream, this both shows a confusing duplicate line to end users and silently inflates any sum/total computed over `txns` for the affected period.

## Fix

Adds `dedupePendingTransactions` (exported from `visa-cal.ts` for direct unit testing) and calls it right after `convertParsedDataToTransactions`, before the existing date-range filtering.

It matches each `pending` transaction to a `completed` transaction with the same `description`, the same calendar day, and the closest timestamp (regardless of amount), and drops the pending side once a match is found. Matching is done 1:1 (each completed transaction can only be consumed by one pending match) so that two separate, still-genuinely-pending charges at the same merchant on the same day aren't incorrectly collapsed into one.

## Testing

- `npm run type-check` and `npm run lint` pass.
- Added 6 unit tests (all using synthetic, made-up data) covering: the exact-duplicate case, the placeholder-hold case, the settlement-adjustment case, a still-pending transaction with no completed counterpart (must be kept), two same-day pending/completed pairs at the same merchant (must pair correctly, not cross-match), and pending/completed transactions on different days (must not match).
- All existing `visa-cal.test.ts` tests still pass (the two API-integration tests are skipped, as expected, without configured credentials).